### PR TITLE
Fix data race in ValueStore snapshot methods

### DIFF
--- a/values.go
+++ b/values.go
@@ -194,7 +194,9 @@ func (vs *ValueStore) Snapshot(devices *DeviceRegistry, filter *EventFilter) []D
 				continue
 			}
 		}
-		entries = append(entries, entry{key: k, val: *v})
+		cp := *v
+		cp.Data = append([]byte(nil), v.Data...)
+		entries = append(entries, entry{key: k, val: cp})
 	}
 	vs.mu.RUnlock()
 
@@ -308,7 +310,9 @@ func (vs *ValueStore) DecodedSnapshot(devices *DeviceRegistry, filter *EventFilt
 				continue
 			}
 		}
-		entries = append(entries, entry{key: k, val: *v})
+		cp := *v
+		cp.Data = append([]byte(nil), v.Data...)
+		entries = append(entries, entry{key: k, val: cp})
 	}
 	vs.mu.RUnlock()
 


### PR DESCRIPTION
## Summary

- **Fix data race** in `ValueStore.Snapshot()` and `DecodedSnapshot()` that caused corrupted decoded values on `/values` and `/values/decoded` endpoints
- `valueEntry` struct copies via `*v` only copy the slice header for `Data`, not the underlying bytes — after releasing `RLock`, the broker's `Record()` reuses the same backing array via `append(entry.Data[:0], data...)`, so the snapshot reads partially overwritten frame data
- Observed as battery voltage showing 17.47V in the dashboard instead of the actual 13.52V from PGN 127508
- Fix: deep-copy `Data` bytes while still holding the read lock

## Test plan

- [x] All existing ValueStore tests pass
- [x] Race detector clean (`go test -race`)
- [ ] Deploy to lplex-server and verify dashboard voltage matches `lplex dump --decode` output