### PR TITLE
Add default-boat config setting and LPLEX_BOAT env var

### DIFF
--- a/cmd/lplex/cmd_dashboard.go
+++ b/cmd/lplex/cmd_dashboard.go
@@ -376,14 +376,9 @@ func runDashboard(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("--boat and --server are mutually exclusive")
 	}
 
-	var boat *BoatConfig
-	var mdnsTimeout time.Duration
-	if boatSet || flagConfig != "" {
-		var err error
-		boat, mdnsTimeout, _, _, err = loadBoatConfig(flagBoat, flagConfig, boatSet)
-		if err != nil {
-			return err
-		}
+	boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, boatSet)
+	if err != nil {
+		return err
 	}
 
 	serverURL := resolveServerURL(flagServer, boat, mdnsTimeout)

--- a/cmd/lplex/cmd_devices.go
+++ b/cmd/lplex/cmd_devices.go
@@ -38,14 +38,11 @@ func runDevices(cmd *cobra.Command, _ []string) error {
 	}
 	log.SetFlags(log.Ltime)
 
-	serverURL := resolveServerURL(flagServer, nil, 0)
-	if flagBoat != "" || flagConfig != "" {
-		boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, flagBoat != "")
-		if err != nil {
-			return err
-		}
-		serverURL = resolveServerURL(flagServer, boat, mdnsTimeout)
+	boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, flagBoat != "")
+	if err != nil {
+		return err
 	}
+	serverURL := resolveServerURL(flagServer, boat, mdnsTimeout)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()

--- a/cmd/lplex/cmd_dump.go
+++ b/cmd/lplex/cmd_dump.go
@@ -131,10 +131,10 @@ func runDump(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("--boat and --server are mutually exclusive")
 	}
 
-	// Load config if --boat is set or --config is specified.
+	// Load config and resolve boat.
 	var boat *BoatConfig
 	var mdnsTimeout time.Duration
-	if boatSet || flagConfig != "" {
+	{
 		var cfgExPGNs []uint32
 		var cfgExNames []string
 		var err error

--- a/cmd/lplex/cmd_request.go
+++ b/cmd/lplex/cmd_request.go
@@ -49,14 +49,11 @@ func runRequest(_ *cobra.Command, _ []string) error {
 	}
 	log.SetFlags(log.Ltime)
 
-	serverURL := resolveServerURL(flagServer, nil, 0)
-	if flagBoat != "" || flagConfig != "" {
-		boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, flagBoat != "")
-		if err != nil {
-			return err
-		}
-		serverURL = resolveServerURL(flagServer, boat, mdnsTimeout)
+	boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, flagBoat != "")
+	if err != nil {
+		return err
 	}
+	serverURL := resolveServerURL(flagServer, boat, mdnsTimeout)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()

--- a/cmd/lplex/cmd_send.go
+++ b/cmd/lplex/cmd_send.go
@@ -44,14 +44,11 @@ func runSend(_ *cobra.Command, _ []string) error {
 		log.SetOutput(io.Discard)
 	}
 
-	serverURL := resolveServerURL(flagServer, nil, 0)
-	if flagBoat != "" || flagConfig != "" {
-		boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, flagBoat != "")
-		if err != nil {
-			return err
-		}
-		serverURL = resolveServerURL(flagServer, boat, mdnsTimeout)
+	boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, flagBoat != "")
+	if err != nil {
+		return err
 	}
+	serverURL := resolveServerURL(flagServer, boat, mdnsTimeout)
 
 	data, err := hex.DecodeString(sendData)
 	if err != nil {

--- a/cmd/lplex/cmd_switches.go
+++ b/cmd/lplex/cmd_switches.go
@@ -118,14 +118,11 @@ func runSwitches(_ *cobra.Command, _ []string) error {
 	}
 	log.SetFlags(log.Ltime)
 
-	serverURL := resolveServerURL(flagServer, nil, 0)
-	if flagBoat != "" || flagConfig != "" {
-		boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, flagBoat != "")
-		if err != nil {
-			return err
-		}
-		serverURL = resolveServerURL(flagServer, boat, mdnsTimeout)
+	boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, flagBoat != "")
+	if err != nil {
+		return err
 	}
+	serverURL := resolveServerURL(flagServer, boat, mdnsTimeout)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -258,14 +255,11 @@ func runSwitchesSet(_ *cobra.Command, args []string) error {
 	}
 	log.SetFlags(log.Ltime)
 
-	serverURL := resolveServerURL(flagServer, nil, 0)
-	if flagBoat != "" || flagConfig != "" {
-		boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, flagBoat != "")
-		if err != nil {
-			return err
-		}
-		serverURL = resolveServerURL(flagServer, boat, mdnsTimeout)
+	boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, flagBoat != "")
+	if err != nil {
+		return err
 	}
+	serverURL := resolveServerURL(flagServer, boat, mdnsTimeout)
 
 	// Parse switch=state pairs from args.
 	type switchSet struct {

--- a/cmd/lplex/cmd_tail.go
+++ b/cmd/lplex/cmd_tail.go
@@ -83,7 +83,7 @@ func runTail(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	// Load config if --boat is set.
+	// Load config and resolve boat.
 	boatSet := cmd.Flags().Changed("boat") || rootCmd.PersistentFlags().Changed("boat")
 	if boatSet && flagServer != "" {
 		return fmt.Errorf("--boat and --server are mutually exclusive")
@@ -91,7 +91,7 @@ func runTail(cmd *cobra.Command, _ []string) error {
 
 	var boat *BoatConfig
 	var mdnsTimeout time.Duration
-	if boatSet || flagConfig != "" {
+	{
 		var cfgExPGNs []uint32
 		var cfgExNames []string
 		var err error

--- a/cmd/lplex/cmd_tail_test.go
+++ b/cmd/lplex/cmd_tail_test.go
@@ -89,16 +89,23 @@ func TestTailEphemeralReceivesFrames(t *testing.T) {
 	defer func() { _ = sub.Close() }()
 
 	// Inject more frames while subscribed.
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		time.Sleep(100 * time.Millisecond)
 		for i := range 5 {
-			broker.RxFrames() <- lplex.RxFrame{
+			select {
+			case broker.RxFrames() <- lplex.RxFrame{
 				Timestamp: time.Now(),
 				Header:    lplex.CANHeader{Priority: 2, PGN: 129025, Source: 1, Destination: 0xFF},
 				Data:      []byte{byte(i + 100), 1, 2, 3, 4, 5, 6, 7},
+			}:
+			case <-ctx.Done():
+				return
 			}
 		}
 	}()
+	defer func() { <-done }()
 
 	// Read at least one event.
 	ev, err := sub.Next()

--- a/cmd/lplex/cmd_values.go
+++ b/cmd/lplex/cmd_values.go
@@ -49,14 +49,11 @@ func runValues(cmd *cobra.Command, _ []string) error {
 	}
 	log.SetFlags(log.Ltime)
 
-	serverURL := resolveServerURL(flagServer, nil, 0)
-	if flagBoat != "" || flagConfig != "" {
-		boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, flagBoat != "")
-		if err != nil {
-			return err
-		}
-		serverURL = resolveServerURL(flagServer, boat, mdnsTimeout)
+	boat, mdnsTimeout, _, _, err := loadBoatConfig(flagBoat, flagConfig, flagBoat != "")
+	if err != nil {
+		return err
 	}
+	serverURL := resolveServerURL(flagServer, boat, mdnsTimeout)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()

--- a/cmd/lplex/config.go
+++ b/cmd/lplex/config.go
@@ -24,6 +24,7 @@ type BoatConfig struct {
 // DumpConfig holds global settings from the config file.
 type DumpConfig struct {
 	Boats        map[string]BoatConfig
+	DefaultBoat  string        // auto-select this boat when --boat is not specified
 	MDNSTimeout  time.Duration // 0 means use default (3s)
 	ExcludePGNs  []uint32      // PGNs to exclude globally (all boats)
 	ExcludeNames []string      // CAN NAMEs to exclude globally (all boats)
@@ -79,6 +80,9 @@ func loadConfig(path string) (DumpConfig, error) {
 		}
 		dc.MDNSTimeout = d
 	}
+
+	// Parse default-boat.
+	dc.DefaultBoat = getString(cfg, "default-boat")
 
 	// Parse global exclude-pgn list.
 	ep, err := getUint32Array(cfg, "exclude-pgn")
@@ -189,28 +193,37 @@ func getUint32Array(cfg *hocon.Config, path string) ([]uint32, error) {
 
 // resolveBoat picks the right boat config. If name is empty and there's exactly
 // one boat defined, it auto-selects it.
-func resolveBoat(name string, boats map[string]BoatConfig) (BoatConfig, error) {
-	if len(boats) == 0 {
+func resolveBoat(name string, dc DumpConfig) (BoatConfig, error) {
+	if len(dc.Boats) == 0 {
 		return BoatConfig{}, fmt.Errorf("no boats configured in config file")
 	}
 
 	if name == "" {
-		if len(boats) == 1 {
-			for _, bc := range boats {
+		// Check LPLEX_BOAT env var, then default-boat config.
+		if env := os.Getenv("LPLEX_BOAT"); env != "" {
+			name = env
+		} else if dc.DefaultBoat != "" {
+			name = dc.DefaultBoat
+		}
+	}
+
+	if name == "" {
+		if len(dc.Boats) == 1 {
+			for _, bc := range dc.Boats {
 				return bc, nil
 			}
 		}
-		names := make([]string, 0, len(boats))
-		for n := range boats {
+		names := make([]string, 0, len(dc.Boats))
+		for n := range dc.Boats {
 			names = append(names, n)
 		}
-		return BoatConfig{}, fmt.Errorf("multiple boats configured, specify one with -boat: %v", names)
+		return BoatConfig{}, fmt.Errorf("multiple boats configured, specify one with --boat: %v", names)
 	}
 
-	bc, ok := boats[name]
+	bc, ok := dc.Boats[name]
 	if !ok {
-		names := make([]string, 0, len(boats))
-		for n := range boats {
+		names := make([]string, 0, len(dc.Boats))
+		for n := range dc.Boats {
 			names = append(names, n)
 		}
 		return BoatConfig{}, fmt.Errorf("boat %q not found in config, available: %v", name, names)

--- a/cmd/lplex/config_test.go
+++ b/cmd/lplex/config_test.go
@@ -277,3 +277,106 @@ boats {
 		t.Errorf("test ExcludeNames = %v, want [00A1B2C3D4E5F600]", dc.Boats["test"].ExcludeNames)
 	}
 }
+
+func TestLoadConfig_DefaultBoat(t *testing.T) {
+	path := writeConfig(t, `
+default-boat = "sv-dockwise"
+
+boats {
+  sv-dockwise {
+    mdns = "inuc1"
+  }
+  test-bench {
+    mdns = "testpi"
+  }
+}
+`)
+	dc, err := loadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dc.DefaultBoat != "sv-dockwise" {
+		t.Errorf("DefaultBoat = %q, want %q", dc.DefaultBoat, "sv-dockwise")
+	}
+}
+
+func TestResolveBoat_DefaultBoatFromConfig(t *testing.T) {
+	dc := DumpConfig{
+		DefaultBoat: "sv-dockwise",
+		Boats: map[string]BoatConfig{
+			"sv-dockwise": {Name: "sv-dockwise", MDNS: "inuc1"},
+			"test-bench":  {Name: "test-bench", MDNS: "testpi"},
+		},
+	}
+	// Empty name should resolve to default-boat.
+	bc, err := resolveBoat("", dc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bc.Name != "sv-dockwise" {
+		t.Errorf("resolved boat = %q, want %q", bc.Name, "sv-dockwise")
+	}
+}
+
+func TestResolveBoat_EnvOverridesDefaultBoat(t *testing.T) {
+	dc := DumpConfig{
+		DefaultBoat: "sv-dockwise",
+		Boats: map[string]BoatConfig{
+			"sv-dockwise": {Name: "sv-dockwise", MDNS: "inuc1"},
+			"test-bench":  {Name: "test-bench", MDNS: "testpi"},
+		},
+	}
+	t.Setenv("LPLEX_BOAT", "test-bench")
+	bc, err := resolveBoat("", dc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bc.Name != "test-bench" {
+		t.Errorf("resolved boat = %q, want %q", bc.Name, "test-bench")
+	}
+}
+
+func TestResolveBoat_ExplicitOverridesAll(t *testing.T) {
+	dc := DumpConfig{
+		DefaultBoat: "sv-dockwise",
+		Boats: map[string]BoatConfig{
+			"sv-dockwise": {Name: "sv-dockwise", MDNS: "inuc1"},
+			"test-bench":  {Name: "test-bench", MDNS: "testpi"},
+		},
+	}
+	t.Setenv("LPLEX_BOAT", "sv-dockwise")
+	bc, err := resolveBoat("test-bench", dc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bc.Name != "test-bench" {
+		t.Errorf("resolved boat = %q, want %q", bc.Name, "test-bench")
+	}
+}
+
+func TestResolveBoat_InvalidDefaultBoat(t *testing.T) {
+	dc := DumpConfig{
+		DefaultBoat: "nonexistent",
+		Boats: map[string]BoatConfig{
+			"sv-dockwise": {Name: "sv-dockwise", MDNS: "inuc1"},
+		},
+	}
+	_, err := resolveBoat("", dc)
+	if err == nil {
+		t.Fatal("expected error for invalid default-boat")
+	}
+}
+
+func TestResolveBoat_InvalidEnvBoat(t *testing.T) {
+	dc := DumpConfig{
+		DefaultBoat: "sv-dockwise",
+		Boats: map[string]BoatConfig{
+			"sv-dockwise": {Name: "sv-dockwise", MDNS: "inuc1"},
+		},
+	}
+	t.Setenv("LPLEX_BOAT", "nonexistent")
+	_, err := resolveBoat("", dc)
+	if err == nil {
+		t.Fatal("expected error for invalid LPLEX_BOAT")
+	}
+}

--- a/cmd/lplex/resolve.go
+++ b/cmd/lplex/resolve.go
@@ -69,7 +69,11 @@ func discoverAny(timeout time.Duration) (string, error) {
 	return lplexc.Discover(context.Background())
 }
 
-// loadBoatConfig loads config and resolves the boat if --boat is set.
+// loadBoatConfig loads config and resolves the boat.
+// When boatSet is true, it requires a matching boat (explicit --boat).
+// When boatSet is false, it checks LPLEX_BOAT env var, then default-boat config,
+// then auto-selects if only one boat is defined. Returns boat=nil if no boats
+// are configured and no default is set.
 // Returns the resolved boat config (or nil), the mdns timeout, and merged exclusion lists.
 func loadBoatConfig(boatName, configPath string, boatSet bool) (boat *BoatConfig, mdnsTimeout time.Duration, excludePGNs []uint32, excludeNames []string, err error) {
 	cfgPath := configPath
@@ -86,9 +90,14 @@ func loadBoatConfig(boatName, configPath string, boatSet bool) (boat *BoatConfig
 	excludePGNs = append(excludePGNs, dc.ExcludePGNs...)
 	excludeNames = append(excludeNames, dc.ExcludeNames...)
 
-	if boatSet {
-		bc, err := resolveBoat(boatName, dc.Boats)
+	if boatSet || len(dc.Boats) > 0 {
+		bc, err := resolveBoat(boatName, dc)
 		if err != nil {
+			// When not explicitly requested, a resolution failure just means
+			// no default boat — fall through to mDNS discovery.
+			if !boatSet {
+				return nil, mdnsTimeout, excludePGNs, excludeNames, nil
+			}
 			return nil, 0, nil, nil, err
 		}
 		boat = &bc

--- a/website/docs/user-guide/lplex.md
+++ b/website/docs/user-guide/lplex.md
@@ -112,6 +112,11 @@ Create `~/.config/lplex/lplex.conf` (HOCON format):
 # How long to wait for mDNS discovery before giving up (default: 3s)
 mdns-timeout = 5s
 
+# Default boat to connect to when --boat is not specified.
+# With this set, running `lplex dump` connects to sv-dockwise automatically.
+# Override with LPLEX_BOAT env var or --boat flag.
+default-boat = "sv-dockwise"
+
 # PGNs to exclude globally (applies to all boats)
 exclude-pgn = [60928, 126996]
 
@@ -139,6 +144,7 @@ boats {
 
 | Setting | Default | Description |
 |---|---|---|
+| `default-boat` | | Boat to connect to when `--boat` is not specified. Overridden by `LPLEX_BOAT` env var. |
 | `mdns-timeout` | `3s` | How long to wait for mDNS discovery before falling back to cloud |
 | `exclude-pgn` | | PGNs to exclude globally, applies to all boats. Array or single value. |
 | `exclude-name` | | CAN NAMEs (hex) to exclude globally, applies to all boats. Array or single value. |
@@ -159,15 +165,32 @@ When you run `lplex dump --boat sv-dockwise`:
 
 On reconnect (with `--reconnect`, which is on by default), the mDNS-then-cloud resolution runs again. So if you sail into WiFi range, lplex automatically switches back to the local connection.
 
+### Default boat
+
+Set `default-boat` in the config to skip the `--boat` flag entirely:
+
+```hocon
+default-boat = "sv-dockwise"
+```
+
+Now `lplex dump` connects to `sv-dockwise` without any flags. Override with `LPLEX_BOAT` env var or `--boat` flag:
+
+```bash
+LPLEX_BOAT=test-bench lplex dump    # env var overrides config
+lplex dump --boat test-bench        # flag overrides both
+```
+
+Priority: `--boat` flag > `LPLEX_BOAT` env var > `default-boat` config > auto-select (single boat).
+
 ### Auto-select
 
-If only one boat is defined in the config, you can pass an empty name and it auto-selects:
+If only one boat is defined and no default is set, it auto-selects:
 
 ```bash
 lplex dump --boat ""
 ```
 
-With multiple boats, the name is required.
+With multiple boats and no `default-boat`, the name is required.
 
 :::note
 `--boat` is mutually exclusive with `--server` and `--file`. Either the `--boat` flag handles discovery or you specify a server directly.


### PR DESCRIPTION
## Summary

- Add `default-boat` config setting to `~/.config/lplex/lplex.conf` that auto-selects a boat when `--boat` is not specified
- Add `LPLEX_BOAT` environment variable that overrides the config setting
- Priority: `--boat` flag > `LPLEX_BOAT` env var > `default-boat` config > auto-select (single boat) > mDNS discovery
- All subcommands now always load config to check for defaults, not just when `--boat`/`--config` flags are set

Example config:
```hocon
default-boat = "sv-dockwise"

boats {
  sv-dockwise { mdns = "inuc1", cloud = "https://..." }
  test-bench  { mdns = "testpi" }
}
```

Now `lplex dump` connects to sv-dockwise automatically. Override with:
```bash
LPLEX_BOAT=test-bench lplex dump    # env var
lplex dump --boat test-bench        # flag
```

## Test plan

- [x] New unit tests for `default-boat` config parsing, env var override, explicit flag override, and invalid boat names
- [x] All existing config tests pass
- [x] `golangci-lint` clean
- [ ] Manual: verify `lplex dump` auto-connects with `default-boat` set
- [ ] Manual: verify `LPLEX_BOAT` overrides config default