### PR TITLE
Make all integer and enum PGN fields nullable with omitempty

### DIFF
--- a/cmd/lplex/testdata/golden/dump_decode_json.golden
+++ b/cmd/lplex/testdata/golden/dump_decode_json.golden
@@ -1,5 +1,5 @@
 {"data":"10270000d0490100","decoded":{"latitude":0.001,"longitude":0.0084432},"dst":255,"pgn":129025,"prio":2,"src":1,"ts":"2025-06-15T12:00:00Z"}
-{"data":"01201c409cffffff","decoded":{"sid":1,"water_temperature":72,"outside_temperature":400,"atmospheric_pressure":null},"dst":255,"pgn":130310,"prio":2,"src":1,"ts":"2025-06-15T12:00:00.1Z"}
+{"data":"01201c409cffffff","decoded":{"sid":1,"water_temperature":72,"outside_temperature":400},"dst":255,"pgn":130310,"prio":2,"src":1,"ts":"2025-06-15T12:00:00.1Z"}
 {"data":"00ae1ef6ff0a0001","decoded":{"sid":0,"heading":0.7854,"deviation":-0.001,"variation":0.001,"heading_reference":"magnetic"},"dst":255,"pgn":127250,"prio":2,"src":2,"ts":"2025-06-15T12:00:00.2Z"}
 {"data":"00fcff204e6400ff","decoded":{"sid":0,"cog_reference":"true","cog":0.8447,"sog":256.78000000000003},"dst":255,"pgn":129026,"prio":2,"src":1,"ts":"2025-06-15T12:00:00.3Z"}
-{"data":"00c800ffffffffff","decoded":{"sid":0,"speed_water":2,"speed_ground":null,"speed_type":null},"dst":255,"pgn":128259,"prio":2,"src":3,"ts":"2025-06-15T12:00:00.4Z"}
+{"data":"00c800ffffffffff","decoded":{"sid":0,"speed_water":2},"dst":255,"pgn":128259,"prio":2,"src":3,"ts":"2025-06-15T12:00:00.4Z"}

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -173,7 +173,7 @@ func TestNeedsDecode(t *testing.T) {
 
 func TestDecodedFieldsEnvironmentalParams(t *testing.T) {
 	decoded := pgn.EnvironmentalParametersOutside{
-		Sid:                 1,
+		Sid:                 ptr[uint8](1),
 		WaterTemperature:    ptr(280.15), // ~7C
 		OutsideTemperature:  ptr(293.15), // ~20C
 		AtmosphericPressure: ptr(101300.0),
@@ -226,9 +226,9 @@ func TestLookupFields(t *testing.T) {
 	// VictronBatteryRegister with register=0xFFF -> "State of Charge"
 	decoded := pgn.VictronBatteryRegister{
 		ManufacturerCode: 358,
-		IndustryCode:     4,
+		IndustryCode:     ptr[uint8](4),
 		Register:         0xFFF,
-		Payload:          500,
+		Payload:          ptr[uint32](500),
 	}
 
 	tests := []struct {
@@ -460,7 +460,7 @@ func TestNegativeNumber(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	decoded := pgn.EnvironmentalParametersOutside{Sid: 0}
+	decoded := pgn.EnvironmentalParametersOutside{Sid: ptr[uint8](0)}
 	ctx := &EvalContext{PGN: 130310, Decoded: decoded}
 	if !f.Match(ctx) {
 		t.Error("expected match: 0 > -1")

--- a/pgn/ais_test.go
+++ b/pgn/ais_test.go
@@ -24,14 +24,14 @@ func TestAISClassAPositionReportDecode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if m.MessageId != 3 {
-		t.Errorf("message_id = %d, want 3", m.MessageId)
+	if m.MessageId == nil || *m.MessageId != 3 {
+		t.Errorf("message_id = %v, want 3", m.MessageId)
 	}
-	if m.RepeatIndicator != 0 {
-		t.Errorf("repeat_indicator = %d, want 0", m.RepeatIndicator)
+	if m.RepeatIndicator == nil || *m.RepeatIndicator != 0 {
+		t.Errorf("repeat_indicator = %v, want 0", m.RepeatIndicator)
 	}
-	if m.UserId != 367608860 {
-		t.Errorf("user_id = %d, want 367608860", m.UserId)
+	if m.UserId == nil || *m.UserId != 367608860 {
+		t.Errorf("user_id = %v, want 367608860", m.UserId)
 	}
 	if m.Longitude == nil || math.Abs(*m.Longitude-(-122.3042)) > 0.001 {
 		t.Errorf("longitude = %v, want ~-122.3042", m.Longitude)
@@ -45,8 +45,8 @@ func TestAISClassAPositionReportDecode(t *testing.T) {
 	if m.Raim != 0 {
 		t.Errorf("raim = %d, want 0", m.Raim)
 	}
-	if m.TimeStamp != 23 {
-		t.Errorf("time_stamp = %d, want 23", m.TimeStamp)
+	if m.TimeStamp == nil || *m.TimeStamp != 23 {
+		t.Errorf("time_stamp = %v, want 23", m.TimeStamp)
 	}
 	if m.Cog == nil || math.Abs(*m.Cog-2.2702) > 0.001 {
 		t.Errorf("cog = %v, want ~2.2702", m.Cog)
@@ -57,35 +57,35 @@ func TestAISClassAPositionReportDecode(t *testing.T) {
 	if m.NavStatus == nil || *m.NavStatus != NavStatusUnderWayUsingEngine {
 		t.Errorf("nav_status = %v, want %d (under_way_using_engine)", m.NavStatus, NavStatusUnderWayUsingEngine)
 	}
-	if m.Sid != 0xfe {
-		t.Errorf("sid = 0x%02x, want 0xfe", m.Sid)
+	if m.Sid == nil || *m.Sid != 0xfe {
+		t.Errorf("sid = %v, want 0xfe", m.Sid)
 	}
 }
 
 func TestAISClassAPositionReportRoundTrip(t *testing.T) {
 	orig := AISClassAPositionReport{
-		MessageId:          1,
-		UserId:             366468000,
+		MessageId:          ptr[uint8](1),
+		UserId:             ptr[uint32](366468000),
 		Longitude:          ptr(-122.1864),
 		Latitude:           ptr(48.0348),
 		PositionAccuracy:   1,
-		TimeStamp:          22,
+		TimeStamp:          ptr[uint8](22),
 		Cog:                ptr(2.9158),
 		Heading:            ptr(4.4148),
 		AisTransceiverInfo: ptr(AISTransceiverChannelBVdl),
 		NavStatus:          ptr(NavStatusUnderWayUsingEngine),
-		Sid:                0xfe,
+		Sid:                ptr[uint8](0xfe),
 	}
 	data := orig.Encode()
 	decoded, err := DecodeAISClassAPositionReport(data)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decoded.MessageId != 1 {
-		t.Errorf("message_id = %d, want 1", decoded.MessageId)
+	if decoded.MessageId == nil || *decoded.MessageId != 1 {
+		t.Errorf("message_id = %v, want 1", decoded.MessageId)
 	}
-	if decoded.UserId != 366468000 {
-		t.Errorf("user_id = %d, want 366468000", decoded.UserId)
+	if decoded.UserId == nil || *decoded.UserId != 366468000 {
+		t.Errorf("user_id = %v, want 366468000", decoded.UserId)
 	}
 	if decoded.Longitude == nil || math.Abs(*decoded.Longitude-*orig.Longitude) > 1e-6 {
 		t.Errorf("longitude = %v, want ~%v", decoded.Longitude, orig.Longitude)
@@ -113,11 +113,11 @@ func TestAISClassBPositionReportDecode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if m.MessageId != 18 {
-		t.Errorf("message_id = %d, want 18", m.MessageId)
+	if m.MessageId == nil || *m.MessageId != 18 {
+		t.Errorf("message_id = %v, want 18", m.MessageId)
 	}
-	if m.UserId != 338165266 {
-		t.Errorf("user_id = %d, want 338165266", m.UserId)
+	if m.UserId == nil || *m.UserId != 338165266 {
+		t.Errorf("user_id = %v, want 338165266", m.UserId)
 	}
 	if m.Longitude == nil || math.Abs(*m.Longitude-(-122.2233)) > 0.001 {
 		t.Errorf("longitude = %v, want ~-122.2233", m.Longitude)
@@ -125,8 +125,8 @@ func TestAISClassBPositionReportDecode(t *testing.T) {
 	if m.Latitude == nil || math.Abs(*m.Latitude-47.9959) > 0.001 {
 		t.Errorf("latitude = %v, want ~47.9959", m.Latitude)
 	}
-	if m.TimeStamp != 23 {
-		t.Errorf("time_stamp = %d, want 23", m.TimeStamp)
+	if m.TimeStamp == nil || *m.TimeStamp != 23 {
+		t.Errorf("time_stamp = %v, want 23", m.TimeStamp)
 	}
 	if m.Cog == nil || math.Abs(*m.Cog-0.7381) > 0.001 {
 		t.Errorf("cog = %v, want ~0.7381", m.Cog)
@@ -138,11 +138,11 @@ func TestAISClassBPositionReportDecode(t *testing.T) {
 
 func TestAISClassBPositionReportRoundTrip(t *testing.T) {
 	orig := AISClassBPositionReport{
-		MessageId:          18,
-		UserId:             338165266,
+		MessageId:          ptr[uint8](18),
+		UserId:             ptr[uint32](338165266),
 		Longitude:          ptr(-122.2233),
 		Latitude:           ptr(47.9959),
-		TimeStamp:          23,
+		TimeStamp:          ptr[uint8](23),
 		Cog:                ptr(0.7381),
 		AisTransceiverInfo: ptr(AISTransceiverChannelBVdl),
 	}
@@ -151,11 +151,11 @@ func TestAISClassBPositionReportRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decoded.MessageId != 18 {
-		t.Errorf("message_id = %d, want 18", decoded.MessageId)
+	if decoded.MessageId == nil || *decoded.MessageId != 18 {
+		t.Errorf("message_id = %v, want 18", decoded.MessageId)
 	}
-	if decoded.UserId != 338165266 {
-		t.Errorf("user_id = %d, want 338165266", decoded.UserId)
+	if decoded.UserId == nil || *decoded.UserId != 338165266 {
+		t.Errorf("user_id = %v, want 338165266", decoded.UserId)
 	}
 	if decoded.Longitude == nil || math.Abs(*decoded.Longitude-*orig.Longitude) > 1e-6 {
 		t.Errorf("longitude = %v, want ~%v", decoded.Longitude, orig.Longitude)
@@ -171,14 +171,14 @@ func TestAISAidsToNavigationReportDecode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if m.MessageId != 21 {
-		t.Errorf("message_id = %d, want 21", m.MessageId)
+	if m.MessageId == nil || *m.MessageId != 21 {
+		t.Errorf("message_id = %v, want 21", m.MessageId)
 	}
-	if m.RepeatIndicator != 0 {
-		t.Errorf("repeat_indicator = %d, want 0", m.RepeatIndicator)
+	if m.RepeatIndicator == nil || *m.RepeatIndicator != 0 {
+		t.Errorf("repeat_indicator = %v, want 0", m.RepeatIndicator)
 	}
-	if m.UserId != 993692022 {
-		t.Errorf("user_id = %d, want 993692022", m.UserId)
+	if m.UserId == nil || *m.UserId != 993692022 {
+		t.Errorf("user_id = %v, want 993692022", m.UserId)
 	}
 	if m.Longitude == nil || math.Abs(*m.Longitude-(-122.6613)) > 0.001 {
 		t.Errorf("longitude = %v, want ~-122.6613", m.Longitude)
@@ -186,14 +186,14 @@ func TestAISAidsToNavigationReportDecode(t *testing.T) {
 	if m.Latitude == nil || math.Abs(*m.Latitude-48.1131) > 0.001 {
 		t.Errorf("latitude = %v, want ~48.1131", m.Latitude)
 	}
-	if m.TimeStamp != 61 {
-		t.Errorf("time_stamp = %d, want 61", m.TimeStamp)
+	if m.TimeStamp == nil || *m.TimeStamp != 61 {
+		t.Errorf("time_stamp = %v, want 61", m.TimeStamp)
 	}
 	if m.VirtualAtonFlag != 1 {
 		t.Errorf("virtual_aton_flag = %d, want 1", m.VirtualAtonFlag)
 	}
-	if m.AtonType != 19 {
-		t.Errorf("aton_type = %d, want 19", m.AtonType)
+	if m.AtonType == nil || *m.AtonType != 19 {
+		t.Errorf("aton_type = %v, want 19", m.AtonType)
 	}
 	if m.AtonName != "SB" {
 		t.Errorf("aton_name = %q, want %q", m.AtonName, "SB")
@@ -209,11 +209,11 @@ func TestAISUTCAndDateReportDecode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if m.MessageId != 4 {
-		t.Errorf("message_id = %d, want 4", m.MessageId)
+	if m.MessageId == nil || *m.MessageId != 4 {
+		t.Errorf("message_id = %v, want 4", m.MessageId)
 	}
-	if m.UserId != 3669153 {
-		t.Errorf("user_id = %d, want 3669153", m.UserId)
+	if m.UserId == nil || *m.UserId != 3669153 {
+		t.Errorf("user_id = %v, want 3669153", m.UserId)
 	}
 	if m.Longitude == nil || math.Abs(*m.Longitude-(-122.6262)) > 0.001 {
 		t.Errorf("longitude = %v, want ~-122.6262", m.Longitude)
@@ -232,8 +232,8 @@ func TestAISUTCAndDateReportDecode(t *testing.T) {
 		t.Errorf("position_time = %v, want ~1711.0", m.PositionTime)
 	}
 	// position_date: days since 1970-01-01 = 20491 = 2026-02-07
-	if m.PositionDate != 20491 {
-		t.Errorf("position_date = %d, want 20491", m.PositionDate)
+	if m.PositionDate == nil || *m.PositionDate != 20491 {
+		t.Errorf("position_date = %v, want 20491", m.PositionDate)
 	}
 }
 
@@ -246,11 +246,11 @@ func TestAISClassBStaticDataPartADecode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if m.MessageId != 24 {
-		t.Errorf("message_id = %d, want 24", m.MessageId)
+	if m.MessageId == nil || *m.MessageId != 24 {
+		t.Errorf("message_id = %v, want 24", m.MessageId)
 	}
-	if m.UserId != 367645940 {
-		t.Errorf("user_id = %d, want 367645940", m.UserId)
+	if m.UserId == nil || *m.UserId != 367645940 {
+		t.Errorf("user_id = %v, want 367645940", m.UserId)
 	}
 	want := "ALICE MARIE"
 	if m.Name != want {
@@ -267,14 +267,14 @@ func TestAISClassBStaticDataPartBDecode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if m.MessageId != 24 {
-		t.Errorf("message_id = %d, want 24", m.MessageId)
+	if m.MessageId == nil || *m.MessageId != 24 {
+		t.Errorf("message_id = %v, want 24", m.MessageId)
 	}
-	if m.UserId != 338432329 {
-		t.Errorf("user_id = %d, want 338432329", m.UserId)
+	if m.UserId == nil || *m.UserId != 338432329 {
+		t.Errorf("user_id = %v, want 338432329", m.UserId)
 	}
-	if m.ShipType != 37 {
-		t.Errorf("ship_type = %d, want 37", m.ShipType)
+	if m.ShipType == nil || *m.ShipType != 37 {
+		t.Errorf("ship_type = %v, want 37", m.ShipType)
 	}
 	// ship_length: 90 * 0.1 = 9.0m
 	if m.ShipLength == nil || math.Abs(*m.ShipLength-9.0) > 0.1 {
@@ -293,8 +293,8 @@ func TestAISClassBStaticDataPartBDecode(t *testing.T) {
 		t.Errorf("position_ref_bow = %v, want 3.0", m.PositionRefBow)
 	}
 	// mothership_mmsi: 0xFFFFFFFF = not available
-	if m.MothershipMmsi != 0xFFFFFFFF {
-		t.Errorf("mothership_mmsi = %d, want 4294967295", m.MothershipMmsi)
+	if m.MothershipMmsi != nil {
+		t.Errorf("mothership_mmsi = %v, want nil (not available)", m.MothershipMmsi)
 	}
 }
 
@@ -322,8 +322,8 @@ func TestAISClassARegistryEntry(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected AISClassAPositionReport, got %T", v)
 	}
-	if m.UserId != 367608860 {
-		t.Errorf("user_id = %d, want 367608860", m.UserId)
+	if m.UserId == nil || *m.UserId != 367608860 {
+		t.Errorf("user_id = %v, want 367608860", m.UserId)
 	}
 }
 

--- a/pgn/gnss_sats_test.go
+++ b/pgn/gnss_sats_test.go
@@ -14,11 +14,11 @@ func TestDecodeGNSSSatsInView(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 
-	if m.Sid != 0x69 {
-		t.Errorf("SID = %d, want %d", m.Sid, 0x69)
+	if m.Sid == nil || *m.Sid != 0x69 {
+		t.Errorf("SID = %v, want %d", m.Sid, 0x69)
 	}
-	if m.RangeResidualMode != 1 {
-		t.Errorf("RangeResidualMode = %d, want 1", m.RangeResidualMode)
+	if m.RangeResidualMode == nil || *m.RangeResidualMode != 1 {
+		t.Errorf("RangeResidualMode = %v, want 1", m.RangeResidualMode)
 	}
 	if m.SatsInView != 10 {
 		t.Errorf("SatsInView = %d, want 10", m.SatsInView)
@@ -29,12 +29,12 @@ func TestDecodeGNSSSatsInView(t *testing.T) {
 
 	// Spot-check first satellite.
 	s0 := m.Satellites[0]
-	if s0.Prn != 3 {
-		t.Errorf("sat[0].PRN = %d, want 3", s0.Prn)
+	if s0.Prn == nil || *s0.Prn != 3 {
+		t.Errorf("sat[0].PRN = %v, want 3", s0.Prn)
 	}
 	// Status should be a small value (0-5).
-	if s0.Status > 5 {
-		t.Errorf("sat[0].Status = %d, want <= 5", s0.Status)
+	if s0.Status == nil || *s0.Status > 5 {
+		t.Errorf("sat[0].Status = %v, want <= 5", s0.Status)
 	}
 }
 

--- a/pgn/iso_request_test.go
+++ b/pgn/iso_request_test.go
@@ -12,8 +12,8 @@ func TestDecodeISORequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if m.RequestedPgn != 60928 {
-		t.Errorf("RequestedPgn = %d, want 60928", m.RequestedPgn)
+	if m.RequestedPgn == nil || *m.RequestedPgn != 60928 {
+		t.Errorf("RequestedPgn = %v, want 60928", m.RequestedPgn)
 	}
 }
 
@@ -24,20 +24,20 @@ func TestDecodeISORequestShortPads(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	want := uint32(0x00FFFF00)
-	if m.RequestedPgn != want {
-		t.Errorf("RequestedPgn = %d, want %d", m.RequestedPgn, want)
+	if m.RequestedPgn == nil || *m.RequestedPgn != want {
+		t.Errorf("RequestedPgn = %v, want %d", m.RequestedPgn, want)
 	}
 }
 
 func TestDecodeISORequestEncode(t *testing.T) {
-	m := ISORequest{RequestedPgn: 60928}
+	m := ISORequest{RequestedPgn: ptr[uint32](60928)}
 	data := m.Encode()
 	m2, err := DecodeISORequest(data)
 	if err != nil {
 		t.Fatalf("decode roundtrip: %v", err)
 	}
-	if m2.RequestedPgn != 60928 {
-		t.Errorf("roundtrip: got %d, want 60928", m2.RequestedPgn)
+	if m2.RequestedPgn == nil || *m2.RequestedPgn != 60928 {
+		t.Errorf("roundtrip: got %v, want 60928", m2.RequestedPgn)
 	}
 }
 

--- a/pgn/packets_test.go
+++ b/pgn/packets_test.go
@@ -45,7 +45,7 @@ var packetTests = []packetTest{
 		desc: "ISO Request for Address Claim (PGN 60928)",
 		pgn:  59904,
 		hex:  "00ee00",
-		want: ISORequest{RequestedPgn: 60928},
+		want: ISORequest{RequestedPgn: ptr[uint32](60928)},
 	},
 
 	// ---- PGN 126992: System Time ----
@@ -54,9 +54,9 @@ var packetTests = []packetTest{
 		pgn:  126992,
 		hex:  "ff00204e00000000",
 		want: SystemTime{
-			Sid:           0xff,
-			TimeSource:    0,
-			DaysSince1970: 20000,
+			Sid:           nil, // 0xFF = not available
+			TimeSource:    ptr[uint8](0),
+			DaysSince1970: ptr[uint16](20000),
 			SecondsToday:  ptr(0.0),
 		},
 	},
@@ -67,7 +67,7 @@ var packetTests = []packetTest{
 		pgn:  127245,
 		hex:  "00ffff7f3fffffff",
 		want: Rudder{
-			Instance:       0,
+			Instance:       ptr[uint8](0),
 			DirectionOrder: nil,
 			AngleOrder:     nil,
 			Position:       ptr(-0.0193),
@@ -83,7 +83,7 @@ var packetTests = []packetTest{
 		hex:  "ff107b0000000000",
 		// heading = 0x7B10 = 31504 * 0.0001 = 3.1504 rad
 		want: VesselHeading{
-			Sid:              0xff,
+			Sid:              nil, // 0xFF = not available
 			Heading:          ptr(3.1504),
 			Deviation:        ptr(0.0),
 			Variation:        ptr(0.0),
@@ -99,7 +99,7 @@ var packetTests = []packetTest{
 		// variation = 0x000a = 10 -> 0.001 rad
 		// heading_reference = 1 (magnetic)
 		want: VesselHeading{
-			Sid:              0,
+			Sid:              ptr[uint8](0),
 			Heading:          ptr(0.7854),
 			Deviation:        ptr(-0.001),
 			Variation:        ptr(0.001),
@@ -114,7 +114,7 @@ var packetTests = []packetTest{
 		pgn:  127251,
 		hex:  "ff00000000ffffff",
 		want: RateOfTurn{
-			Sid:  0xff,
+			Sid:  nil, // 0xFF = not available
 			Rate: ptr(0.0),
 		},
 	},
@@ -125,7 +125,7 @@ var packetTests = []packetTest{
 		pgn:  127257,
 		hex:  "0000000000000000",
 		want: Attitude{
-			Sid:   0,
+			Sid:   ptr[uint8](0),
 			Yaw:   ptr(0.0),
 			Pitch: ptr(0.0),
 			Roll:  ptr(0.0),
@@ -139,7 +139,7 @@ var packetTests = []packetTest{
 		// pitch = 0x03e8 = 1000 -> 0.1 rad
 		// roll = 0x000a = 10 -> 0.001 rad
 		want: Attitude{
-			Sid:   0xff,
+			Sid:   nil, // 0xFF = not available
 			Yaw:   ptr(0.0),
 			Pitch: ptr(0.1),
 			Roll:  ptr(0.001),
@@ -154,9 +154,9 @@ var packetTests = []packetTest{
 		hex:  "fff1204e9cffffff",
 		// source = 1 (magnetic), days = 20000, variation = -100 -> -0.01 rad
 		want: MagneticVariation{
-			Sid:           0xff,
+			Sid:           nil, // 0xFF = not available
 			Source:        ptr(HeadingReferenceMagnetic),
-			DaysSince1970: 20000,
+			DaysSince1970: ptr[uint16](20000),
 			Variation:     ptr(-0.01),
 		},
 		epsilon: 1e-4,
@@ -171,7 +171,7 @@ var packetTests = []packetTest{
 		// speed_ground = 0x0190 = 400 -> 4.00 m/s
 		// speed_type = 0 (paddle_wheel)
 		want: SpeedWaterReferenced{
-			Sid:         0,
+			Sid:         ptr[uint8](0),
 			SpeedWater:  ptr(3.5),
 			SpeedGround: ptr(4.0),
 			SpeedType:   ptr(SpeedTypePaddleWheel),
@@ -184,7 +184,7 @@ var packetTests = []packetTest{
 		pgn:  128267,
 		hex:  "ff3d020000a5fa0e",
 		want: WaterDepth{
-			Sid:    0xff,
+			Sid:    nil, // 0xFF = not available
 			Depth:  ptr(5.73),
 			Offset: ptr(-1.371),
 			Range:  ptr(140.0),
@@ -196,7 +196,7 @@ var packetTests = []packetTest{
 		hex:  "00960000000000ff",
 		// depth = 150 -> 1.50 m, offset = 0, range = 0xff = not available
 		want: WaterDepth{
-			Sid:    0,
+			Sid:    ptr[uint8](0),
 			Depth:  ptr(1.50),
 			Offset: ptr(0.0),
 			Range:  nil,
@@ -212,8 +212,8 @@ var packetTests = []packetTest{
 		// level = 18750 * 0.004 = 75.0%
 		// capacity = 2000 * 0.1 = 200.0 L
 		want: FluidLevel{
-			Instance:  5,
-			FluidType: 0,
+			Instance:  ptr[uint8](5),
+			FluidType: ptr[uint8](0),
 			Level:     ptr(75.0),
 			Capacity:  ptr(200.0),
 		},
@@ -229,11 +229,11 @@ var packetTests = []packetTest{
 		// current = 0xfe38 = -456 as int16 * 0.1 = -45.6A
 		// temperature = 0x05fa = 1530 * 0.01 = 15.30K
 		want: BatteryStatus{
-			Instance:    0,
+			Instance:    ptr[uint8](0),
 			Voltage:     ptr(202.12),
 			Current:     ptr(-45.6),
 			Temperature: ptr(15.30),
-			Sid:         0,
+			Sid:         ptr[uint8](0),
 		},
 		epsilon: 0.1,
 	},
@@ -282,7 +282,7 @@ var packetTests = []packetTest{
 		// cog = 0x3d5c = 15708 -> 1.5708 rad ≈ 90°
 		// sog = 0x01f4 = 500 -> 5.00 m/s
 		want: COGSOGRapidUpdate{
-			Sid:          0xff,
+			Sid:          nil, // 0xFF = not available
 			CogReference: ptr(HeadingReferenceTrue),
 			Cog:          ptr(1.5708),
 			Sog:          ptr(5.0),
@@ -299,7 +299,7 @@ var packetTests = []packetTest{
 		// angle = 0x3039 = 12345 -> 1.2345 rad
 		// wind_reference = 2 (apparent)
 		want: WindData{
-			Sid:           1,
+			Sid:           ptr[uint8](1),
 			WindSpeed:     ptr(5.50),
 			WindAngle:     ptr(1.2345),
 			WindReference: ptr(WindReferenceApparent),
@@ -313,7 +313,7 @@ var packetTests = []packetTest{
 		// angle = 0 -> 0 rad
 		// reference = 0 (true_north)
 		want: WindData{
-			Sid:           0,
+			Sid:           ptr[uint8](0),
 			WindSpeed:     ptr(10.0),
 			WindAngle:     ptr(0.0),
 			WindReference: ptr(WindReferenceTrueNorth),
@@ -326,22 +326,22 @@ var packetTests = []packetTest{
 		pgn:  129794,
 		hex:  "05823df315ffffffff57444e32343738434f4e54494e55554d202020202020202020202025c800320014007800ffffffffffff8c00455645524554542020202020202020202020202001e1",
 		want: AISClassAStaticAndVoyageRelatedData{
-			MessageId:            5,
-			RepeatIndicator:      0,
-			UserId:               368262530,
-			ImoNumber:            0xFFFFFFFF,
+			MessageId:            ptr[uint8](5),
+			RepeatIndicator:      ptr[uint8](0),
+			UserId:               ptr[uint32](368262530),
+			ImoNumber:            nil, // 0xFFFFFFFF = not available
 			Callsign:             "WDN2478",
 			Name:                 "CONTINUUM",
-			ShipType:             37,
+			ShipType:             ptr[uint8](37),
 			ShipLength:           ptr(20.0),
 			ShipBeam:             ptr(5.0),
 			PositionRefStarboard: ptr(2.0),
 			PositionRefBow:       ptr(12.0),
-			EtaDate:              0xFFFF,
+			EtaDate:              nil, // 0xFFFF = not available
 			EtaTime:              nil, // 0xFFFFFFFF = not available
 			Draught:              ptr(1.40),
 			Destination:          "EVERETT",
-			AisVersionIndicator:  1,
+			AisVersionIndicator:  ptr[uint8](1),
 			GnssType:             ptr(PositionFixTypeUndefined),
 			Dte:                  0,
 			AisTransceiverInfo:   ptr(AISTransceiverChannelBVdl),
@@ -358,8 +358,8 @@ var packetTests = []packetTest{
 		// actual = 0x7283 = 29315 * 0.01 = 293.15K
 		// set = 0
 		want: Temperature{
-			Sid:               0xff,
-			Instance:          0,
+			Sid:               nil, // 0xFF = not available
+			Instance:          ptr[uint8](0),
 			TemperatureSource: ptr(TemperatureSource(2)),
 			ActualTemperature: ptr(293.15),
 			SetTemperature:    ptr(0.0),
@@ -373,14 +373,14 @@ var packetTests = []packetTest{
 		pgn:  127500,
 		hex:  "ff00000000640000",
 		want: LoadControllerConnectionStateControl{
-			Sid:                      0xff,
-			ConnectionId:             0,
-			State:                    0,
-			Status:                   0,
-			OperationalStatusControl: 0,
-			PwmDutyCycle:             100,
-			TimeOn:                   0,
-			TimeOff:                  0,
+			Sid:                      nil, // 0xFF = not available
+			ConnectionId:             ptr[uint8](0),
+			State:                    ptr[uint8](0),
+			Status:                   ptr[uint8](0),
+			OperationalStatusControl: ptr[uint8](0),
+			PwmDutyCycle:             ptr[uint8](100),
+			TimeOn:                   ptr[uint8](0),
+			TimeOff:                  ptr[uint8](0),
 		},
 	},
 	{
@@ -388,8 +388,8 @@ var packetTests = []packetTest{
 		pgn:  127500,
 		hex:  "ff05000000000000",
 		want: LoadControllerConnectionStateControl{
-			Sid:          0xff,
-			ConnectionId: 5,
+			Sid:          nil, // 0xFF = not available
+			ConnectionId: ptr[uint8](5),
 		},
 	},
 
@@ -399,8 +399,8 @@ var packetTests = []packetTest{
 		pgn:  127751,
 		hex:  "ff000000000000ff",
 		want: DCVoltageCurrent{
-			Sid:              0xff,
-			ConnectionNumber: 0,
+			Sid:              nil, // 0xFF = not available
+			ConnectionNumber: ptr[uint8](0),
 			DcVoltage:        ptr(0.0),
 			DcCurrent:        ptr(0.0),
 		},
@@ -415,7 +415,7 @@ var packetTests = []packetTest{
 		want: NMEAGroupFunctionCommand{
 			FunctionCode:    1,
 			CommandedPgn:    127501,
-			PrioritySetting: 8, // 0x8 = don't change priority
+			PrioritySetting: ptr[uint8](8), // 0x8 = don't change priority
 			NumberOfPairs:   2,
 			Params: []ParamPair{
 				{Field: 1, Name: "instance", Value: 32},
@@ -430,10 +430,10 @@ var packetTests = []packetTest{
 		noRoundTrip: true,
 		want: NMEAGroupFunctionAcknowledge{
 			FunctionCode:     2,
-			AcknowledgedPgn:  127501,
-			PgnErrorCode:     4,
-			ControlErrorCode: 4,
-			NumberOfPairs:    0xFF,
+			AcknowledgedPgn:  ptr[uint32](127501),
+			PgnErrorCode:     ptr[uint8](4),
+			ControlErrorCode: ptr[uint8](4),
+			NumberOfPairs:    nil, // 0xFF = not available
 		},
 	},
 	{
@@ -443,10 +443,10 @@ var packetTests = []packetTest{
 		noRoundTrip: true,
 		want: NMEAGroupFunctionAcknowledge{
 			FunctionCode:     2,
-			AcknowledgedPgn:  127501,
-			PgnErrorCode:     0,
-			ControlErrorCode: 0,
-			NumberOfPairs:    2,
+			AcknowledgedPgn:  ptr[uint32](127501),
+			PgnErrorCode:     ptr[uint8](0),
+			ControlErrorCode: ptr[uint8](0),
+			NumberOfPairs:    ptr[uint8](2),
 			Params:           HexBytes{0x00},
 		},
 	},

--- a/pgn/pgn_test.go
+++ b/pgn/pgn_test.go
@@ -51,7 +51,7 @@ func TestPositionRapidUpdateDecodeKnown(t *testing.T) {
 
 func TestWindDataRoundTrip(t *testing.T) {
 	orig := WindData{
-		Sid:           1,
+		Sid:           ptr[uint8](1),
 		WindSpeed:     ptr(5.5),
 		WindAngle:     ptr(1.2345),
 		WindReference: ptr(WindReferenceApparent),
@@ -62,8 +62,8 @@ func TestWindDataRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if decoded.Sid != 1 {
-		t.Errorf("sid = %d, want 1", decoded.Sid)
+	if decoded.Sid == nil || *decoded.Sid != 1 {
+		t.Errorf("sid = %v, want 1", decoded.Sid)
 	}
 	if decoded.WindSpeed == nil || math.Abs(*decoded.WindSpeed-5.5) > 0.01 {
 		t.Errorf("wind_speed = %v, want ~5.5", decoded.WindSpeed)
@@ -78,11 +78,11 @@ func TestWindDataRoundTrip(t *testing.T) {
 
 func TestBatteryStatusRoundTrip(t *testing.T) {
 	orig := BatteryStatus{
-		Instance:    0,
+		Instance:    ptr[uint8](0),
 		Voltage:     ptr(12.85),
 		Current:     ptr(-5.3),
 		Temperature: ptr(293.15),
-		Sid:         42,
+		Sid:         ptr[uint8](42),
 	}
 	data := orig.Encode()
 	decoded, err := DecodeBatteryStatus(data)
@@ -90,8 +90,8 @@ func TestBatteryStatusRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if decoded.Instance != 0 {
-		t.Errorf("instance = %d, want 0", decoded.Instance)
+	if decoded.Instance == nil || *decoded.Instance != 0 {
+		t.Errorf("instance = %v, want 0", decoded.Instance)
 	}
 	if decoded.Voltage == nil || math.Abs(*decoded.Voltage-12.85) > 0.01 {
 		t.Errorf("voltage = %v, want ~12.85", decoded.Voltage)
@@ -102,14 +102,14 @@ func TestBatteryStatusRoundTrip(t *testing.T) {
 	if decoded.Temperature == nil || math.Abs(*decoded.Temperature-293.15) > 0.01 {
 		t.Errorf("temperature = %v, want ~293.15", decoded.Temperature)
 	}
-	if decoded.Sid != 42 {
-		t.Errorf("sid = %d, want 42", decoded.Sid)
+	if decoded.Sid == nil || *decoded.Sid != 42 {
+		t.Errorf("sid = %v, want 42", decoded.Sid)
 	}
 }
 
 func TestVesselHeadingRoundTrip(t *testing.T) {
 	orig := VesselHeading{
-		Sid:               0,
+		Sid:               ptr[uint8](0),
 		Heading:           ptr(3.14),
 		Deviation:         ptr(-0.05),
 		Variation:         ptr(0.1),
@@ -133,7 +133,7 @@ func TestVesselHeadingRoundTrip(t *testing.T) {
 
 func TestWaterDepthRoundTrip(t *testing.T) {
 	orig := WaterDepth{
-		Sid:    0,
+		Sid:    ptr[uint8](0),
 		Depth:  ptr(15.25),
 		Offset: ptr(-0.5),
 		Range:  ptr(100.0),
@@ -164,9 +164,9 @@ func TestWaterDepthDecodeAirmarFrame(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// sid = 0xff
-	if decoded.Sid != 0xff {
-		t.Errorf("sid = %d, want 255", decoded.Sid)
+	// sid = 0xff = not available
+	if decoded.Sid != nil {
+		t.Errorf("sid = %v, want nil (not available)", decoded.Sid)
 	}
 	// depth = 0x0000023d = 573 -> 573 * 0.01 = 5.73m
 	if decoded.Depth == nil || math.Abs(*decoded.Depth-5.73) > 0.01 {
@@ -184,22 +184,22 @@ func TestWaterDepthDecodeAirmarFrame(t *testing.T) {
 
 func TestProductInformationRoundTrip(t *testing.T) {
 	orig := ProductInformation{
-		NmeaVersion:     2100,
-		ProductCode:     1234,
+		NmeaVersion:     ptr[uint16](2100),
+		ProductCode:     ptr[uint16](1234),
 		ModelId:         "GPS 200",
 		SoftwareVersion: "v3.1.0",
 		ModelVersion:    "Rev B",
 		ModelSerial:     "ABC12345",
-		CertLevel:       1,
-		LoadEquiv:       2,
+		CertLevel:       ptr[uint8](1),
+		LoadEquiv:       ptr[uint8](2),
 	}
 	data := orig.Encode()
 	decoded, err := DecodeProductInformation(data)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decoded.ProductCode != 1234 {
-		t.Errorf("product_code = %d, want 1234", decoded.ProductCode)
+	if decoded.ProductCode == nil || *decoded.ProductCode != 1234 {
+		t.Errorf("product_code = %v, want 1234", decoded.ProductCode)
 	}
 	if decoded.ModelId != "GPS 200" {
 		t.Errorf("model_id = %q, want GPS 200", decoded.ModelId)
@@ -276,8 +276,8 @@ func TestPGNMethod(t *testing.T) {
 func TestFluidLevelBitFields(t *testing.T) {
 	// Fluid Level has 4-bit instance and 4-bit fluid_type in the first byte
 	orig := FluidLevel{
-		Instance:  3,
-		FluidType: 5,
+		Instance:  ptr[uint8](3),
+		FluidType: ptr[uint8](5),
 		Level:     ptr(75.0),
 		Capacity:  ptr(200.0),
 	}
@@ -286,11 +286,11 @@ func TestFluidLevelBitFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decoded.Instance != 3 {
-		t.Errorf("instance = %d, want 3", decoded.Instance)
+	if decoded.Instance == nil || *decoded.Instance != 3 {
+		t.Errorf("instance = %v, want 3", decoded.Instance)
 	}
-	if decoded.FluidType != 5 {
-		t.Errorf("fluid_type = %d, want 5", decoded.FluidType)
+	if decoded.FluidType == nil || *decoded.FluidType != 5 {
+		t.Errorf("fluid_type = %v, want 5", decoded.FluidType)
 	}
 	if decoded.Level == nil || math.Abs(*decoded.Level-75.0) > 0.01 {
 		t.Errorf("level = %v, want ~75.0", decoded.Level)

--- a/pgn/proprietary_test.go
+++ b/pgn/proprietary_test.go
@@ -19,8 +19,8 @@ func TestDecodeVictronSOC(t *testing.T) {
 	if m.ManufacturerCode != 358 {
 		t.Errorf("ManufacturerCode = %d, want 358", m.ManufacturerCode)
 	}
-	if m.IndustryCode != 4 {
-		t.Errorf("IndustryCode = %d, want 4", m.IndustryCode)
+	if m.IndustryCode == nil || *m.IndustryCode != 4 {
+		t.Errorf("IndustryCode = %v, want 4", m.IndustryCode)
 	}
 	if m.Register != 0x0FFF {
 		t.Errorf("Register = 0x%04X, want 0x0FFF", m.Register)
@@ -28,8 +28,8 @@ func TestDecodeVictronSOC(t *testing.T) {
 	if m.RegisterName() != "State of Charge" {
 		t.Errorf("RegisterName() = %q, want %q", m.RegisterName(), "State of Charge")
 	}
-	if m.Payload != 10000 {
-		t.Errorf("Payload = %d, want 10000", m.Payload)
+	if m.Payload == nil || *m.Payload != 10000 {
+		t.Errorf("Payload = %v, want 10000", m.Payload)
 	}
 }
 
@@ -50,8 +50,8 @@ func TestDecodeVictronCurrent(t *testing.T) {
 	if m.RegisterName() != "DC Channel 1 Current" {
 		t.Errorf("RegisterName() = %q, want %q", m.RegisterName(), "DC Channel 1 Current")
 	}
-	if m.Payload != 33 {
-		t.Errorf("Payload = %d, want 33", m.Payload)
+	if m.Payload == nil || *m.Payload != 33 {
+		t.Errorf("Payload = %v, want 33", m.Payload)
 	}
 }
 
@@ -72,8 +72,8 @@ func TestDecodeVictronDeviceMode(t *testing.T) {
 	if m.RegisterName() != "Device Mode" {
 		t.Errorf("RegisterName() = %q, want %q", m.RegisterName(), "Device Mode")
 	}
-	if m.Payload != 3 {
-		t.Errorf("Payload = %d, want 3", m.Payload)
+	if m.Payload == nil || *m.Payload != 3 {
+		t.Errorf("Payload = %v, want 3", m.Payload)
 	}
 }
 
@@ -140,9 +140,9 @@ func TestProprietaryRegistry(t *testing.T) {
 
 func TestVictronBatteryRegisterEncode(t *testing.T) {
 	m := VictronBatteryRegister{
-		IndustryCode: 4,
-		Register:   0x0FFF,
-		Payload:      10000,
+		IndustryCode: ptr[uint8](4),
+		Register:     0x0FFF,
+		Payload:      ptr[uint32](10000),
 	}
 	data := m.Encode()
 	// Decode it back via the dispatch function to verify round-trip.
@@ -161,8 +161,8 @@ func TestVictronBatteryRegisterEncode(t *testing.T) {
 	if got.Register != 0x0FFF {
 		t.Errorf("Register = 0x%04X, want 0x0FFF", got.Register)
 	}
-	if got.Payload != 10000 {
-		t.Errorf("Payload = %d, want 10000", got.Payload)
+	if got.Payload == nil || *got.Payload != 10000 {
+		t.Errorf("Payload = %v, want 10000", got.Payload)
 	}
 }
 
@@ -170,9 +170,9 @@ func TestVictronEncodeIgnoresManufacturerCodeField(t *testing.T) {
 	// Encode should hardcode manufacturer_code=358 regardless of the struct value.
 	m := VictronBatteryRegister{
 		ManufacturerCode: 999, // garbage, should be ignored
-		IndustryCode:     4,
-		Register:       0x0200,
-		Payload:          42,
+		IndustryCode:     ptr[uint8](4),
+		Register:         0x0200,
+		Payload:          ptr[uint32](42),
 	}
 	data := m.Encode()
 	got, err := DecodeVictronBatteryRegister(data)
@@ -182,8 +182,8 @@ func TestVictronEncodeIgnoresManufacturerCodeField(t *testing.T) {
 	if got.ManufacturerCode != 358 {
 		t.Errorf("ManufacturerCode = %d, want 358 (hardcoded)", got.ManufacturerCode)
 	}
-	if got.Payload != 42 {
-		t.Errorf("Payload = %d, want 42", got.Payload)
+	if got.Payload == nil || *got.Payload != 42 {
+		t.Errorf("Payload = %v, want 42", got.Payload)
 	}
 }
 
@@ -214,12 +214,12 @@ func TestVictronDecodeShortData(t *testing.T) {
 	if m.ManufacturerCode != 358 {
 		t.Errorf("ManufacturerCode = %d, want 358", m.ManufacturerCode)
 	}
-	// Padded with 0xFF: register_id = 0xFFFF, payload = 0xFFFFFFFF.
+	// Padded with 0xFF: register_id = 0xFFFF, payload = nil (0xFFFFFFFF sentinel).
 	if m.Register != 0xFFFF {
 		t.Errorf("Register = 0x%04X, want 0xFFFF (padded)", m.Register)
 	}
-	if m.Payload != 0xFFFFFFFF {
-		t.Errorf("Payload = 0x%08X, want 0xFFFFFFFF (padded)", m.Payload)
+	if m.Payload != nil {
+		t.Errorf("Payload = %v, want nil (0xFFFFFFFF = not available)", m.Payload)
 	}
 }
 
@@ -236,8 +236,8 @@ func TestVictronDecodeEmpty(t *testing.T) {
 	if m.Register != 0xFFFF {
 		t.Errorf("Register = 0x%04X, want 0xFFFF", m.Register)
 	}
-	if m.Payload != 0xFFFFFFFF {
-		t.Errorf("Payload = 0x%08X, want 0xFFFFFFFF", m.Payload)
+	if m.Payload != nil {
+		t.Errorf("Payload = %v, want nil (0xFFFFFFFF = not available)", m.Payload)
 	}
 }
 
@@ -263,8 +263,8 @@ func TestDecodeBEPProprietary(t *testing.T) {
 	if m.ManufacturerCode != 295 {
 		t.Errorf("ManufacturerCode = %d, want 295", m.ManufacturerCode)
 	}
-	if m.IndustryCode != 4 {
-		t.Errorf("IndustryCode = %d, want 4", m.IndustryCode)
+	if m.IndustryCode == nil || *m.IndustryCode != 4 {
+		t.Errorf("IndustryCode = %v, want 4", m.IndustryCode)
 	}
 }
 
@@ -315,8 +315,8 @@ func TestDecodeMastervoltProprietary(t *testing.T) {
 	if m.ManufacturerCode != 176 {
 		t.Errorf("ManufacturerCode = %d, want 176", m.ManufacturerCode)
 	}
-	if m.IndustryCode != 4 {
-		t.Errorf("IndustryCode = %d, want 4", m.IndustryCode)
+	if m.IndustryCode == nil || *m.IndustryCode != 4 {
+		t.Errorf("IndustryCode = %v, want 4", m.IndustryCode)
 	}
 }
 

--- a/pgn/route_wp_test.go
+++ b/pgn/route_wp_test.go
@@ -16,23 +16,23 @@ func TestDecodeNavigationRouteWPInformation(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 
-	if m.StartRps != 0xFFFF {
-		t.Errorf("StartRPS = %d, want %d", m.StartRps, 0xFFFF)
+	if m.StartRps != nil { // 0xFFFF = not available
+		t.Errorf("StartRPS = %v, want nil (not available)", m.StartRps)
 	}
 	if m.Items != 2 {
 		t.Errorf("Items = %d, want 2", m.Items)
 	}
-	if m.DatabaseId != 0xFFFF {
-		t.Errorf("DatabaseID = %d, want %d", m.DatabaseId, 0xFFFF)
+	if m.DatabaseId != nil { // 0xFFFF = not available
+		t.Errorf("DatabaseID = %v, want nil (not available)", m.DatabaseId)
 	}
-	if m.RouteId != 0xFFFF {
-		t.Errorf("RouteID = %d, want %d", m.RouteId, 0xFFFF)
+	if m.RouteId != nil { // 0xFFFF = not available
+		t.Errorf("RouteID = %v, want nil (not available)", m.RouteId)
 	}
-	if m.NavigationDirection != 0 {
-		t.Errorf("NavigationDirection = %d, want 0", m.NavigationDirection)
+	if m.NavigationDirection == nil || *m.NavigationDirection != 0 {
+		t.Errorf("NavigationDirection = %v, want 0", m.NavigationDirection)
 	}
-	if m.SupplementaryData != 0 {
-		t.Errorf("SupplementaryData = %d, want 0", m.SupplementaryData)
+	if m.SupplementaryData == nil || *m.SupplementaryData != 0 {
+		t.Errorf("SupplementaryData = %v, want 0", m.SupplementaryData)
 	}
 	if m.RouteName != "" {
 		t.Errorf("RouteName = %q, want empty", m.RouteName)
@@ -43,8 +43,8 @@ func TestDecodeNavigationRouteWPInformation(t *testing.T) {
 
 	// WP1: all not-available.
 	wp1 := m.Waypoints[0]
-	if wp1.Id != 0xFFFF {
-		t.Errorf("wp[0].ID = %d, want %d", wp1.Id, 0xFFFF)
+	if wp1.Id != nil { // 0xFFFF = not available
+		t.Errorf("wp[0].ID = %v, want nil (not available)", wp1.Id)
 	}
 	if wp1.Name != "" {
 		t.Errorf("wp[0].Name = %q, want empty", wp1.Name)
@@ -59,8 +59,8 @@ func TestDecodeNavigationRouteWPInformation(t *testing.T) {
 
 	// WP2: destination "End" near San Juan Islands.
 	wp2 := m.Waypoints[1]
-	if wp2.Id != 1 {
-		t.Errorf("wp[1].ID = %d, want 1", wp2.Id)
+	if wp2.Id == nil || *wp2.Id != 1 {
+		t.Errorf("wp[1].ID = %v, want 1", wp2.Id)
 	}
 	if wp2.Name != "End" {
 		t.Errorf("wp[1].Name = %q, want %q", wp2.Name, "End")

--- a/pgn/switch_bank_test.go
+++ b/pgn/switch_bank_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBinarySwitchBankRoundTrip(t *testing.T) {
 	orig := BinarySwitchBankStatus{
-		Instance: 1,
+		Instance: ptr[uint8](1),
 		Indicators: []uint8{
 			1, 2, 3, 0, // indicators 1-4 (packed into byte 1)
 			1, 1, 2, 2, // indicators 5-8 (packed into byte 2)
@@ -27,8 +27,8 @@ func TestBinarySwitchBankRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decoded.Instance != 1 {
-		t.Errorf("instance = %d, want 1", decoded.Instance)
+	if decoded.Instance == nil || *decoded.Instance != 1 {
+		t.Errorf("instance = %v, want 1", decoded.Instance)
 	}
 	if len(decoded.Indicators) != 28 {
 		t.Fatalf("len(indicators) = %d, want 28", len(decoded.Indicators))
@@ -55,8 +55,8 @@ func TestBinarySwitchBankDecodeKnownBytes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decoded.Instance != 0 {
-		t.Errorf("instance = %d, want 0", decoded.Instance)
+	if decoded.Instance == nil || *decoded.Instance != 0 {
+		t.Errorf("instance = %v, want 0", decoded.Instance)
 	}
 
 	// First 4 indicators from byte 1 = 0x39
@@ -77,7 +77,7 @@ func TestBinarySwitchBankDecodeKnownBytes(t *testing.T) {
 func TestBinarySwitchBankPartialEncode(t *testing.T) {
 	// Encode with fewer than 28 indicators. Unset indicators should stay 0xFF (3).
 	orig := BinarySwitchBankStatus{
-		Instance:   5,
+		Instance:   ptr[uint8](5),
 		Indicators: []uint8{1, 0}, // only first two
 	}
 	data := orig.Encode()
@@ -86,8 +86,8 @@ func TestBinarySwitchBankPartialEncode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decoded.Instance != 5 {
-		t.Errorf("instance = %d, want 5", decoded.Instance)
+	if decoded.Instance == nil || *decoded.Instance != 5 {
+		t.Errorf("instance = %v, want 5", decoded.Instance)
 	}
 	if decoded.Indicators[0] != 1 {
 		t.Errorf("indicator[0] = %d, want 1", decoded.Indicators[0])
@@ -109,8 +109,8 @@ func TestBinarySwitchBankShortData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decoded.Instance != 2 {
-		t.Errorf("instance = %d, want 2", decoded.Instance)
+	if decoded.Instance == nil || *decoded.Instance != 2 {
+		t.Errorf("instance = %v, want 2", decoded.Instance)
 	}
 	// All indicators from padded 0xFF bytes should be 3.
 	for i := 0; i < 28; i++ {
@@ -139,8 +139,8 @@ func TestBinarySwitchBankRegistry(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected BinarySwitchBankStatus, got %T", v)
 	}
-	if sw.Instance != 3 {
-		t.Errorf("instance = %d, want 3", sw.Instance)
+	if sw.Instance == nil || *sw.Instance != 3 {
+		t.Errorf("instance = %v, want 3", sw.Instance)
 	}
 	if sw.Indicators[0] != 1 {
 		t.Errorf("indicator[0] = %d, want 1", sw.Indicators[0])
@@ -157,7 +157,7 @@ func TestBinarySwitchBankPGN(t *testing.T) {
 func TestBinarySwitchBankControlRoundTrip(t *testing.T) {
 	// Build a control frame: turn switch 1 ON, switch 3 OFF, rest no-change.
 	ctrl := BinarySwitchBankControl{
-		Instance: 0,
+		Instance: ptr[uint8](0),
 	}
 	ctrl.Indicators = make(Uint8s, 28)
 	for i := range ctrl.Indicators {
@@ -194,8 +194,8 @@ func TestBinarySwitchBankControlRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decoded.Instance != 0 {
-		t.Errorf("instance = %d, want 0", decoded.Instance)
+	if decoded.Instance == nil || *decoded.Instance != 0 {
+		t.Errorf("instance = %v, want 0", decoded.Instance)
 	}
 	if decoded.Indicators[0] != 1 {
 		t.Errorf("indicator[0] = %d, want 1 (ON)", decoded.Indicators[0])
@@ -220,7 +220,7 @@ func TestBinarySwitchBankControlRegistry(t *testing.T) {
 
 func TestBinarySwitchBankJSON(t *testing.T) {
 	sw := BinarySwitchBankStatus{
-		Instance:   1,
+		Instance:   ptr[uint8](1),
 		Indicators: Uint8s{1, 2, 3, 0},
 	}
 	data, err := json.Marshal(sw)

--- a/pgngen/gen_go.go
+++ b/pgngen/gen_go.go
@@ -144,6 +144,7 @@ func GenerateGo(s *Schema, pkg string) string {
 	for i := range s.Structs {
 		sd := &s.Structs[i]
 		structMap[sd.Name] = sd
+		refs := referencedFields(sd.Fields)
 		goName := toPascal(sd.Name)
 		fmt.Fprintf(&b, "// %s is a sub-structure entry type.\n", goName)
 		fmt.Fprintf(&b, "type %s struct {\n", goName)
@@ -157,15 +158,26 @@ func GenerateGo(s *Schema, pkg string) string {
 				continue
 			}
 			goType := goFieldType(f)
-			if isNullable(f) {
+			nullable := isNullable(f, refs)
+			if nullable {
 				goType = "*" + goType
 			}
-			tag := fmt.Sprintf("`json:%q`", toSnake(f.Name))
-			comment := ""
-			if f.Unit != "" {
-				comment = " // " + f.Unit
+			jsonName := toSnake(f.Name)
+			if nullable {
+				tag := fmt.Sprintf("`json:\"%s,omitempty\"`", jsonName)
+				comment := ""
+				if f.Unit != "" {
+					comment = " // " + f.Unit
+				}
+				fmt.Fprintf(&b, "\t%s %s %s%s\n", toPascal(f.Name), goType, tag, comment)
+			} else {
+				tag := fmt.Sprintf("`json:%q`", jsonName)
+				comment := ""
+				if f.Unit != "" {
+					comment = " // " + f.Unit
+				}
+				fmt.Fprintf(&b, "\t%s %s %s%s\n", toPascal(f.Name), goType, tag, comment)
 			}
-			fmt.Fprintf(&b, "\t%s %s %s%s\n", toPascal(f.Name), goType, tag, comment)
 		}
 		b.WriteString("}\n\n")
 	}
@@ -470,6 +482,7 @@ func repeatJSONName(f FieldDef) string {
 func writeVariant(b *strings.Builder, p PGNDef) {
 	structName := toPascal(p.Description)
 	minBytes := minBufferBytes(p)
+	refs := referencedFields(p.Fields)
 
 	// Struct
 	fmt.Fprintf(b, "// %s represents PGN %d — %s.\n", structName, p.PGN, p.Description)
@@ -496,15 +509,26 @@ func writeVariant(b *strings.Builder, p PGNDef) {
 			continue
 		}
 		goType := goFieldType(f)
-		if isNullable(f) {
+		nullable := isNullable(f, refs)
+		if nullable {
 			goType = "*" + goType
 		}
-		tag := fmt.Sprintf("`json:%q`", toSnake(f.Name))
-		comment := ""
-		if f.Unit != "" {
-			comment = " // " + f.Unit
+		jsonName := toSnake(f.Name)
+		if nullable {
+			tag := fmt.Sprintf("`json:\"%s,omitempty\"`", jsonName)
+			comment := ""
+			if f.Unit != "" {
+				comment = " // " + f.Unit
+			}
+			fmt.Fprintf(b, "\t%s %s %s%s\n", toPascal(f.Name), goType, tag, comment)
+		} else {
+			tag := fmt.Sprintf("`json:%q`", jsonName)
+			comment := ""
+			if f.Unit != "" {
+				comment = " // " + f.Unit
+			}
+			fmt.Fprintf(b, "\t%s %s %s%s\n", toPascal(f.Name), goType, tag, comment)
 		}
-		fmt.Fprintf(b, "\t%s %s %s%s\n", toPascal(f.Name), goType, tag, comment)
 	}
 	b.WriteString("}\n\n")
 
@@ -530,7 +554,7 @@ func writeVariant(b *strings.Builder, p PGNDef) {
 			continue
 		}
 		goField := toPascal(f.Name)
-		writeDecodeField(b, f, goField)
+		writeDecodeField(b, f, goField, refs)
 	}
 	b.WriteString("\treturn m, nil\n")
 	b.WriteString("}\n\n")
@@ -552,7 +576,7 @@ func writeVariant(b *strings.Builder, p PGNDef) {
 			writeEncodeConstrained(b, f, *f.MatchValue)
 		} else {
 			goField := toPascal(f.Name)
-			writeEncodeField(b, f, goField)
+			writeEncodeField(b, f, goField, refs)
 		}
 	}
 	b.WriteString("\treturn data\n")
@@ -564,6 +588,7 @@ func writeVariant(b *strings.Builder, p PGNDef) {
 // only known at runtime. Uses cursor-based decoding instead of static offsets.
 func writeVariableWidthVariant(b *strings.Builder, p PGNDef, structMap map[string]*StructDef) {
 	structName := toPascal(p.Description)
+	refs := referencedFields(p.Fields)
 
 	// Split fields into static prefix (before first variable-width field) and the rest.
 	splitIdx := 0
@@ -613,15 +638,26 @@ func writeVariableWidthVariant(b *strings.Builder, p PGNDef, structMap map[strin
 			}
 		default:
 			goType := goFieldType(f)
-			if isNullable(f) {
+			nullable := isNullable(f, refs)
+			if nullable {
 				goType = "*" + goType
 			}
-			tag := fmt.Sprintf("`json:%q`", toSnake(f.Name))
-			comment := ""
-			if f.Unit != "" {
-				comment = " // " + f.Unit
+			jsonName := toSnake(f.Name)
+			if nullable {
+				tag := fmt.Sprintf("`json:\"%s,omitempty\"`", jsonName)
+				comment := ""
+				if f.Unit != "" {
+					comment = " // " + f.Unit
+				}
+				fmt.Fprintf(b, "\t%s %s %s%s\n", toPascal(f.Name), goType, tag, comment)
+			} else {
+				tag := fmt.Sprintf("`json:%q`", jsonName)
+				comment := ""
+				if f.Unit != "" {
+					comment = " // " + f.Unit
+				}
+				fmt.Fprintf(b, "\t%s %s %s%s\n", toPascal(f.Name), goType, tag, comment)
 			}
-			fmt.Fprintf(b, "\t%s %s %s%s\n", toPascal(f.Name), goType, tag, comment)
 		}
 	}
 	b.WriteString("}\n\n")
@@ -643,7 +679,7 @@ func writeVariableWidthVariant(b *strings.Builder, p PGNDef, structMap map[strin
 		if f.IsSkipped() {
 			continue
 		}
-		writeDecodeField(b, f, toPascal(f.Name))
+		writeDecodeField(b, f, toPascal(f.Name), refs)
 	}
 
 	// Cursor init for dynamic tail.
@@ -683,7 +719,7 @@ func writeVariableWidthVariant(b *strings.Builder, p PGNDef, structMap map[strin
 				fmt.Fprintf(b, "\t\tm.%s = make([]%s, count)\n", fieldName, goStructType)
 				fmt.Fprintf(b, "\t\tfor i := range count {\n")
 				fmt.Fprintf(b, "\t\t\te := &m.%s[i]\n", fieldName)
-				writeStructFieldDecodes(b, sd, "off", "e", "\t\t\t")
+				writeStructFieldDecodes(b, sd, "off", "e", "\t\t\t", refs)
 				fmt.Fprintf(b, "\t\t\toff += %d\n", entrySize)
 				fmt.Fprintf(b, "\t\t}\n")
 				fmt.Fprintf(b, "\t}\n")
@@ -696,7 +732,7 @@ func writeVariableWidthVariant(b *strings.Builder, p PGNDef, structMap map[strin
 				fmt.Fprintf(b, "\t\tfor range count {\n")
 				fmt.Fprintf(b, "\t\t\tif off+%d > len(data) { break }\n", minFixed)
 				fmt.Fprintf(b, "\t\t\tvar e %s\n", goStructType)
-				writeVarStructFieldDecodes(b, sd, "off", "e", "\t\t\t")
+				writeVarStructFieldDecodes(b, sd, "off", "e", "\t\t\t", refs)
 				fmt.Fprintf(b, "\t\t\tm.%s = append(m.%s, e)\n", fieldName, fieldName)
 				fmt.Fprintf(b, "\t\t}\n")
 				fmt.Fprintf(b, "\t}\n")
@@ -720,7 +756,7 @@ func writeVariableWidthVariant(b *strings.Builder, p PGNDef, structMap map[strin
 			// Regular field in the dynamic tail (shouldn't happen per validation,
 			// but handle gracefully anyway).
 			goField := toPascal(f.Name)
-			writeDecodeField(b, f, goField)
+			writeDecodeField(b, f, goField, refs)
 		}
 	}
 
@@ -732,7 +768,7 @@ func writeVariableWidthVariant(b *strings.Builder, p PGNDef, structMap map[strin
 
 // writeStructFieldDecodes emits decode statements for all fields of a fixed-width struct.
 // Uses compile-time offsets relative to a runtime base variable.
-func writeStructFieldDecodes(b *strings.Builder, sd *StructDef, baseVar, entryVar, indent string) {
+func writeStructFieldDecodes(b *strings.Builder, sd *StructDef, baseVar, entryVar, indent string, refs map[string]bool) {
 	for _, f := range sd.Fields {
 		if f.IsSkipped() {
 			continue
@@ -741,7 +777,7 @@ func writeStructFieldDecodes(b *strings.Builder, sd *StructDef, baseVar, entryVa
 		byteOff := f.BitStart / 8
 		bitInByte := f.BitStart % 8
 		expr := readBitsExprCursor(baseVar, byteOff, bitInByte, f.Bits, f.Signed)
-		if isNullable(f) {
+		if isNullable(f, refs) {
 			unsignedExpr := readBitsExprCursor(baseVar, byteOff, bitInByte, f.Bits, false)
 			sentinel := sentinelHex(f.Bits, f.Signed)
 			if f.Signed {
@@ -753,7 +789,7 @@ func writeStructFieldDecodes(b *strings.Builder, sd *StructDef, baseVar, entryVa
 			if f.Type == TypeEnum {
 				fmt.Fprintf(b, "%s\te := %s(v)\n", indent, f.EnumRef)
 				fmt.Fprintf(b, "%s\t%s.%s = &e\n", indent, entryVar, goField)
-			} else {
+			} else if f.HasScaling() {
 				if f.Signed {
 					fmt.Fprintf(b, "%s\tf := float64(%s(v))", indent, intGoType(f.Bits))
 				} else {
@@ -767,6 +803,14 @@ func writeStructFieldDecodes(b *strings.Builder, sd *StructDef, baseVar, entryVa
 				}
 				b.WriteString("\n")
 				fmt.Fprintf(b, "%s\t%s.%s = &f\n", indent, entryVar, goField)
+			} else {
+				goType := goFieldType(f)
+				if f.Signed {
+					fmt.Fprintf(b, "%s\tn := %s(%s(v))\n", indent, goType, intGoType(f.Bits))
+				} else {
+					fmt.Fprintf(b, "%s\tn := %s(v)\n", indent, goType)
+				}
+				fmt.Fprintf(b, "%s\t%s.%s = &n\n", indent, entryVar, goField)
 			}
 			fmt.Fprintf(b, "%s}\n", indent)
 		} else if f.HasScaling() {
@@ -792,7 +836,7 @@ func writeStructFieldDecodes(b *strings.Builder, sd *StructDef, baseVar, entryVa
 }
 
 // writeVarStructFieldDecodes emits cursor-based decode for a variable-width struct.
-func writeVarStructFieldDecodes(b *strings.Builder, sd *StructDef, offVar, entryVar, indent string) {
+func writeVarStructFieldDecodes(b *strings.Builder, sd *StructDef, offVar, entryVar, indent string, refs map[string]bool) {
 	for _, f := range sd.Fields {
 		if f.Type == TypeStringLAU {
 			goField := toPascal(f.Name)
@@ -820,7 +864,7 @@ func writeVarStructFieldDecodes(b *strings.Builder, sd *StructDef, offVar, entry
 		}
 		bitInByte := f.BitStart % 8 // always 0 for cursor-based (byte aligned within entry)
 		expr := readBitsExprCursor(offVar, 0, bitInByte, f.Bits, f.Signed)
-		if isNullable(f) {
+		if isNullable(f, refs) {
 			unsignedExpr := readBitsExprCursor(offVar, 0, bitInByte, f.Bits, false)
 			sentinel := sentinelHex(f.Bits, f.Signed)
 			if f.Signed {
@@ -832,7 +876,7 @@ func writeVarStructFieldDecodes(b *strings.Builder, sd *StructDef, offVar, entry
 			if f.Type == TypeEnum {
 				fmt.Fprintf(b, "%s\te := %s(v)\n", indent, f.EnumRef)
 				fmt.Fprintf(b, "%s\t%s.%s = &e\n", indent, entryVar, goField)
-			} else {
+			} else if f.HasScaling() {
 				if f.Signed {
 					fmt.Fprintf(b, "%s\tf := float64(%s(v))", indent, intGoType(f.Bits))
 				} else {
@@ -846,6 +890,14 @@ func writeVarStructFieldDecodes(b *strings.Builder, sd *StructDef, offVar, entry
 				}
 				b.WriteString("\n")
 				fmt.Fprintf(b, "%s\t%s.%s = &f\n", indent, entryVar, goField)
+			} else {
+				goType := goFieldType(f)
+				if f.Signed {
+					fmt.Fprintf(b, "%s\tn := %s(%s(v))\n", indent, goType, intGoType(f.Bits))
+				} else {
+					fmt.Fprintf(b, "%s\tn := %s(v)\n", indent, goType)
+				}
+				fmt.Fprintf(b, "%s\t%s.%s = &n\n", indent, entryVar, goField)
 			}
 			fmt.Fprintf(b, "%s}\n", indent)
 		} else if f.HasScaling() {
@@ -1195,7 +1247,7 @@ func encodeRawExpr(f FieldDef, valueExpr string) string {
 }
 
 // writeDecodeField emits Go code to decode one field from data into m.<goField>.
-func writeDecodeField(b *strings.Builder, f FieldDef, goField string) {
+func writeDecodeField(b *strings.Builder, f FieldDef, goField string, refs map[string]bool) {
 	byteOff := f.BitStart / 8
 	bitInByte := f.BitStart % 8
 
@@ -1225,7 +1277,7 @@ func writeDecodeField(b *strings.Builder, f FieldDef, goField string) {
 	// Integer and enum types
 	rawExpr := readBitsExpr(byteOff, bitInByte, f.Bits, f.Signed)
 
-	if isNullable(f) {
+	if isNullable(f, refs) {
 		// Nullable field: read unsigned raw value, check sentinel, assign via pointer.
 		rawUnsigned := readBitsExpr(byteOff, bitInByte, f.Bits, false)
 		sentinel := sentinelHex(f.Bits, f.Signed)
@@ -1240,7 +1292,7 @@ func writeDecodeField(b *strings.Builder, f FieldDef, goField string) {
 		if f.Type == TypeEnum {
 			fmt.Fprintf(b, "\t\te := %s(v)\n", f.EnumRef)
 			fmt.Fprintf(b, "\t\tm.%s = &e\n", goField)
-		} else {
+		} else if f.HasScaling() {
 			if f.Signed {
 				fmt.Fprintf(b, "\t\tf := float64(%s(v))", intGoType(f.Bits))
 			} else {
@@ -1254,6 +1306,15 @@ func writeDecodeField(b *strings.Builder, f FieldDef, goField string) {
 			}
 			b.WriteString("\n")
 			fmt.Fprintf(b, "\t\tm.%s = &f\n", goField)
+		} else {
+			// Plain integer, nullable but no scaling.
+			goType := goFieldType(f)
+			if f.Signed {
+				fmt.Fprintf(b, "\t\tn := %s(%s(v))\n", goType, intGoType(f.Bits))
+			} else {
+				fmt.Fprintf(b, "\t\tn := %s(v)\n", goType)
+			}
+			fmt.Fprintf(b, "\t\tm.%s = &n\n", goField)
 		}
 		b.WriteString("\t}\n")
 	} else if f.HasScaling() {
@@ -1279,7 +1340,7 @@ func writeDecodeField(b *strings.Builder, f FieldDef, goField string) {
 }
 
 // writeEncodeField emits Go code to encode m.<goField> into data.
-func writeEncodeField(b *strings.Builder, f FieldDef, goField string) {
+func writeEncodeField(b *strings.Builder, f FieldDef, goField string, refs map[string]bool) {
 	byteOff := f.BitStart / 8
 	bitInByte := f.BitStart % 8
 
@@ -1303,12 +1364,12 @@ func writeEncodeField(b *strings.Builder, f FieldDef, goField string) {
 
 	// Build the raw integer value from the Go field.
 	// Nullable fields are pointers; skip encode if nil (data is pre-filled 0xFF).
-	if isNullable(f) {
+	if isNullable(f, refs) {
 		fmt.Fprintf(b, "\tif m.%s != nil {\n", goField)
 		var rawExpr string
 		if f.Type == TypeEnum {
 			rawExpr = fmt.Sprintf("uint64(*m.%s)", goField)
-		} else {
+		} else if f.HasScaling() {
 			scale := f.Scale
 			if scale == 0 {
 				scale = 1
@@ -1326,6 +1387,9 @@ func writeEncodeField(b *strings.Builder, f FieldDef, goField string) {
 					rawExpr = fmt.Sprintf("uint64(math.Round(*m.%s / %s))", goField, formatFloat(scale))
 				}
 			}
+		} else {
+			// Plain integer, no scaling.
+			rawExpr = fmt.Sprintf("uint64(*m.%s)", goField)
 		}
 		b.WriteString("\t")
 		writeBitsStmt(b, byteOff, bitInByte, f.Bits, rawExpr)
@@ -1485,15 +1549,51 @@ func writeBitsStmt(b *strings.Builder, byteOff, bitInByte, bits int, rawExpr str
 	fmt.Fprintf(b, "\t\tbinary.LittleEndian.PutUint64(data[%d:%d], v)\n\t}\n", byteOff, byteOff+8)
 }
 
+// referencedFields returns the set of field names that are referenced by other
+// fields (e.g. as repeat counts, PGN refs, or count refs). These fields cannot
+// be nullable because they are used directly in generated code (loop bounds, map keys, etc.).
+func referencedFields(fields []FieldDef) map[string]bool {
+	refs := make(map[string]bool)
+	for _, f := range fields {
+		if f.RepeatRef != "" {
+			refs[f.RepeatRef] = true
+		}
+		if f.PGNRef != "" {
+			refs[f.PGNRef] = true
+		}
+		if f.CountRef != "" {
+			refs[f.CountRef] = true
+		}
+	}
+	return refs
+}
+
 // isNullable returns true if a field should use a pointer type to represent
-// NMEA 2000 "data not available" sentinels as nil/null. Applies to scaled
-// fields (where the sentinel produces garbage numbers) and enum fields
-// (where all-bits-set means "not available" per the NMEA 2000 spec).
-func isNullable(f FieldDef) bool {
+// NMEA 2000 "data not available" sentinels as nil/null. In NMEA 2000,
+// all-bits-set means "data not available" for any field type: unsigned
+// integers, signed integers, scaled fields, and enums. Fields that are
+// referenced by other fields (repeat counts, PGN refs) cannot be nullable.
+func isNullable(f FieldDef, refs map[string]bool) bool {
 	if f.IsRepeated() || f.MatchValue != nil {
 		return false
 	}
-	return f.HasScaling() || f.Type == TypeEnum
+	if refs[f.Name] {
+		return false
+	}
+	if f.LookupRef != "" {
+		return false
+	}
+	// 1-bit fields cannot be nullable: the sentinel (all-bits-set = 1)
+	// overlaps with the only non-zero valid value.
+	if f.Bits == 1 {
+		return false
+	}
+	switch f.Type {
+	case TypeUint, TypeInt, TypeEnum:
+		return true
+	default:
+		return f.HasScaling()
+	}
 }
 
 // sentinelHex returns the hex literal for the NMEA 2000 "not available" sentinel.

--- a/pgngen/gen_test.go
+++ b/pgngen/gen_test.go
@@ -1209,10 +1209,10 @@ pgn 127493 "Test PGN" {
 	code := GenerateGo(s, "pgn")
 
 	// Struct should have engine_instance and known_field but not the unknown.
-	if !strings.Contains(code, "EngineInstance uint8") {
+	if !strings.Contains(code, "EngineInstance *uint8") {
 		t.Error("missing EngineInstance field")
 	}
-	if !strings.Contains(code, "KnownField uint16") {
+	if !strings.Contains(code, "KnownField *uint16") {
 		t.Error("missing KnownField field")
 	}
 	// The unknown field should be skipped from the struct entirely.
@@ -1349,7 +1349,7 @@ pgn 129540 "GNSS Sats in View" fast_packet {
 	if !strings.Contains(code, "type SatelliteInView struct") {
 		t.Error("missing SatelliteInView struct")
 	}
-	if !strings.Contains(code, `Prn uint8 `+"`"+`json:"prn"`+"`") {
+	if !strings.Contains(code, `Prn *uint8 `+"`"+`json:"prn,omitempty"`+"`") {
 		t.Error("missing Prn field in SatelliteInView")
 	}
 	if !strings.Contains(code, "Elevation *float64") {
@@ -1444,7 +1444,8 @@ pgn 129285 "Navigation Route WP Information" fast_packet {
 	}
 
 	// Should have static prefix decode using fixed offsets.
-	if !strings.Contains(code, "m.StartRps = binary.LittleEndian.Uint16(data[0:2])") {
+	// Items is non-nullable (referenced by repeat=items), so it uses direct assignment.
+	if !strings.Contains(code, "m.Items = binary.LittleEndian.Uint16(data[2:4])") {
 		t.Error("static prefix should use fixed offset reads")
 	}
 


### PR DESCRIPTION
## Summary

- Expand `isNullable()` in the PGN code generator to treat all `uint`, `int`, and `enum` fields as nullable, not just scaled fields. NMEA 2000 uses all-bits-set as "data not available" for every field type, so fields like `SID=255` now decode as `nil` instead of `255`.
- Add `omitempty` to all nullable (pointer) field JSON tags so `nil` values are omitted from JSON output instead of appearing as `null`.
- Exclude from nullability: repeated fields, match-value discriminators, referenced fields (repeat counts, PGN/count refs), lookup fields, and 1-bit fields where the sentinel overlaps valid data.

## Test plan

- [x] All existing tests pass (`go test ./... -count=1`)
- [x] Linter passes (`golangci-lint run`)
- [x] Golden file updated to reflect omitted null fields
- [x] PGN packet round-trip tests updated for pointer types
- [ ] Verify on live boat data that SID and other sentinel values no longer appear in decoded JSON