### PR TITLE
Add --cloud flag to force cloud endpoint over mDNS

### DIFF
--- a/cmd/lplex/main.go
+++ b/cmd/lplex/main.go
@@ -22,6 +22,7 @@ var (
 	flagConfig string
 	flagQuiet  bool
 	flagJSON   bool
+	flagCloud  bool
 )
 
 // stringSlice implements pflag.Value for repeatable string flags.
@@ -89,6 +90,7 @@ func init() {
 	pf.StringVar(&flagConfig, "config", "", "config file path (default: ~/.config/lplex/lplex.conf)")
 	pf.BoolVar(&flagQuiet, "quiet", false, "suppress stderr status messages")
 	pf.BoolVar(&flagJSON, "json", false, "force JSON output")
+	pf.BoolVar(&flagCloud, "cloud", false, "force connection to the boat's cloud endpoint (skip mDNS)")
 
 	rootCmd.AddCommand(dumpCmd)
 	rootCmd.AddCommand(inspectCmd)

--- a/cmd/lplex/resolve.go
+++ b/cmd/lplex/resolve.go
@@ -21,6 +21,11 @@ func resolveServerURL(serverFlag string, boat *BoatConfig, mdnsTimeout time.Dura
 		return resolveBoatServer(boat, mdnsTimeout)
 	}
 
+	if flagCloud {
+		fmt.Fprintf(os.Stderr, "--cloud requires a boat with a configured cloud URL (use --boat or define one in the config file)\n")
+		os.Exit(1)
+	}
+
 	// No boat config, try generic mDNS discovery.
 	discovered, err := discoverAny(mdnsTimeout)
 	if err != nil {
@@ -34,6 +39,14 @@ func resolveServerURL(serverFlag string, boat *BoatConfig, mdnsTimeout time.Dura
 
 // resolveBoatServer resolves a server URL for a specific boat config.
 func resolveBoatServer(boat *BoatConfig, mdnsTimeout time.Duration) string {
+	if flagCloud {
+		if boat.Cloud == "" {
+			fmt.Fprintf(os.Stderr, "boat %s: --cloud requested but no cloud URL configured\n", boat.Name)
+			os.Exit(1)
+		}
+		log.Printf("using cloud endpoint for %s: %s", boat.Name, boat.Cloud)
+		return boat.Cloud
+	}
 	if boat.MDNS != "" {
 		url, err := discoverNamed(boat.MDNS, mdnsTimeout)
 		if err == nil {

--- a/website/docs/user-guide/lplex.md
+++ b/website/docs/user-guide/lplex.md
@@ -29,6 +29,7 @@ lplex dump --server http://inuc1.local:8089 --decode
 |---|---|---|
 | `--server` | (mDNS) | Server URL |
 | `--boat` | (empty) | Connect to a named boat (mDNS first, cloud fallback) |
+| `--cloud` | `false` | Force connection to the boat's cloud endpoint (skip mDNS) |
 | `--config` | `~/.config/lplex/lplex.conf` | Path to config file |
 | `--client-id` | hostname | Session ID for buffered mode |
 | `--buffer-timeout` | (empty) | Enable buffered mode with this timeout (ISO 8601) |
@@ -164,6 +165,14 @@ When you run `lplex dump --boat sv-dockwise`:
 3. If mDNS fails, fall back to the configured cloud URL
 
 On reconnect (with `--reconnect`, which is on by default), the mDNS-then-cloud resolution runs again. So if you sail into WiFi range, lplex automatically switches back to the local connection.
+
+To skip the local mDNS lookup and go straight to the cloud endpoint, pass `--cloud`:
+
+```bash
+lplex dump --boat sv-dockwise --cloud
+```
+
+This errors out if the boat has no `cloud` URL configured. `--server` still wins over `--cloud` if both are set.
 
 ### Default boat
 


### PR DESCRIPTION
## Summary
- New `--cloud` persistent flag on `lplex` skips the local mDNS lookup and connects directly to the boat's configured cloud URL.
- Errors out if `--cloud` is set but the boat has no `cloud =` URL configured (or no boat is selected at all), so silent fallback can't mask a misconfiguration.
- Resolution priority is now: explicit `--server` > `--cloud` (boat's cloud URL) > existing mDNS-then-cloud-fallback.

## Test plan
- [ ] `lplex dump --boat <boat-with-cloud> --cloud` connects to the cloud URL without attempting mDNS
- [ ] `lplex dump --boat <boat-without-cloud> --cloud` exits 1 with a clear error
- [ ] `lplex dump --cloud` (no boat) exits 1 with a clear error
- [ ] `lplex dump --server <url> --cloud` still uses `--server`
- [ ] `lplex dump --boat <boat>` (without `--cloud`) preserves existing mDNS-first behavior