### PR TITLE
Add --mdns flag to disable built-in mDNS responder

### DIFF
--- a/cmd/lplex-server/main.go
+++ b/cmd/lplex-server/main.go
@@ -84,6 +84,7 @@ func main() {
 	readOnly := flag.Bool("read-only", false, "Disable /send and /query entirely (defense in depth)")
 	sendRateLimit := flag.Float64("send-rate-limit", 0, "Max requests/sec for /send and /query (0 = unlimited)")
 	sendRateBurst := flag.Int("send-rate-burst", 10, "Max burst size for /send rate limiter")
+	mdnsEnabled := flag.Bool("mdns", true, "Advertise _lplex._tcp via the built-in mDNS responder. Set false on hosts that already run avahi-daemon (or another mDNS responder) to avoid hostname conflicts on UDP/5353.")
 	flag.Parse()
 
 	if *showVersion {
@@ -599,13 +600,17 @@ func main() {
 		}
 	}()
 
-	hostname, _ := os.Hostname()
-	mdns, err := zeroconf.Register(hostname, "_lplex._tcp", "local.", *port, nil, nil)
-	if err != nil {
-		logger.Error("mDNS registration failed", "error", err)
+	if *mdnsEnabled {
+		hostname, _ := os.Hostname()
+		mdns, err := zeroconf.Register(hostname, "_lplex._tcp", "local.", *port, nil, nil)
+		if err != nil {
+			logger.Error("mDNS registration failed", "error", err)
+		} else {
+			defer mdns.Shutdown()
+			logger.Info("mDNS registered", "service", "_lplex._tcp", "port", *port)
+		}
 	} else {
-		defer mdns.Shutdown()
-		logger.Info("mDNS registered", "service", "_lplex._tcp", "port", *port)
+		logger.Info("mDNS responder disabled by --mdns=false")
 	}
 
 	// Notify systemd that the service is ready.


### PR DESCRIPTION
## Summary

- Adds `--mdns=true|false` (default `true`) to `lplex-server`. When `false`, the built-in `zeroconf` registration is skipped.
- Useful on hosts that already run `avahi-daemon` (or another mDNS responder). Two responders on UDP/5353 compete to claim the host name — avahi loses the conflict probe and demotes itself to `<host>-2.local`, which makes `<host>.local` resolution flaky from LAN clients.

## Why

I hit this on a Debian box running `lplex-server` next to `avahi-daemon`. Symptom: `<host>.local` periodically stops resolving from other machines. avahi's journal shows `Host name conflict, retrying with <host>-2`. Setting `--mdns=false` and adding a static avahi service file lets avahi own the hostname uncontested while `_lplex._tcp` stays discoverable.

## Companion config (host side, for the avahi case)

```xml
<!-- /etc/avahi/services/lplex.service -->
<?xml version="1.0" standalone="no"?>
<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
<service-group>
  <name replace-wildcards="yes">%h</name>
  <service>
    <type>_lplex._tcp</type>
    <port>8089</port>
  </service>
</service-group>
```

## Test plan

- [x] `go build ./cmd/lplex-server` clean
- [x] `go vet ./cmd/lplex-server` clean
- [x] `go test ./cmd/...` passes
- [x] `--help` lists the new `-mdns` flag with description
- [ ] Manual: run with `--mdns=false`, confirm log says `mDNS responder disabled by --mdns=false` and HTTP serving is unaffected
- [ ] Manual: run with default `--mdns=true`, confirm `_lplex._tcp` still advertised as before