### PR TITLE
Make lplex dump accept positional journal files

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,8 +545,8 @@ lplex dump --decode
 # JSON output: adds a "decoded" object to each frame
 lplex dump --decode --json
 
-# Journal replay with decoding
-lplex dump --file recording.lpj --decode
+# Journal replay with decoding (pass one or more files as positional args)
+lplex dump recording.lpj --decode
 ```
 
 The registry contains ~120 PGNs, of which ~30 have full decoders (position, heading, wind, depth, engine, battery, environment, etc.). The remaining PGNs are name-only: they carry descriptions and metadata (fast-packet, interval) but no field layout. Unknown PGNs pass through with raw hex data as usual.

--- a/cmd/lplex/cmd_dump.go
+++ b/cmd/lplex/cmd_dump.go
@@ -25,10 +25,12 @@ import (
 )
 
 var dumpCmd = &cobra.Command{
-	Use:   "dump",
+	Use:   "dump [file...]",
 	Short: "Stream or replay NMEA 2000 frames",
-	Long:  "Stream live frames from an lplex server or replay from journal files.",
-	RunE:  runDump,
+	Long: "Stream live frames from an lplex server, or replay from one or more .lpj journal files.\n\n" +
+		"Files passed as positional arguments are replayed sequentially.",
+	Args: cobra.ArbitraryArgs,
+	RunE: runDump,
 }
 
 // Dump-specific flags.
@@ -67,7 +69,7 @@ func init() {
 	// Journal flags.
 	f.StringVar(&dumpFile, "file", "", "replay from .lpj journal file (mutually exclusive with --server)")
 	f.BoolVar(&dumpInspect, "inspect", false, "inspect journal file structure (use with --file)")
-	f.Float64Var(&dumpSpeed, "speed", 1.0, "playback speed multiplier (0 = as fast as possible, 1.0 = real-time)")
+	f.Float64Var(&dumpSpeed, "speed", 0, "playback speed multiplier (0 = as fast as possible, 1.0 = real-time)")
 	f.StringVar(&dumpStartTime, "start", "", "seek to RFC3339 timestamp before replaying")
 
 	// Filter flags.
@@ -80,7 +82,7 @@ func init() {
 	f.StringVar(&dumpWhere, "where", "", `display filter expression (e.g. "water_temperature < 280")`)
 }
 
-func runDump(cmd *cobra.Command, _ []string) error {
+func runDump(cmd *cobra.Command, args []string) error {
 	jsonMode := flagJSON || !isTerminal(os.Stdout)
 
 	if flagQuiet {
@@ -111,18 +113,33 @@ func runDump(cmd *cobra.Command, _ []string) error {
 		return runInspectFile(dumpFile)
 	}
 
-	// Journal replay mode.
+	// Journal replay mode: positional args and/or --file.
+	files := append([]string(nil), args...)
 	if dumpFile != "" {
+		if len(files) > 0 {
+			return fmt.Errorf("--file cannot be combined with positional file arguments")
+		}
+		files = []string{dumpFile}
+	}
+	if len(files) > 0 {
 		if flagServer != "" || dumpBufferTimeout != "" {
-			return fmt.Errorf("--file cannot be used with --server or --buffer-timeout")
+			return fmt.Errorf("journal files cannot be used with --server or --buffer-timeout")
 		}
 		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 		defer cancel()
 
 		devices := newDeviceMap()
-		return runReplay(ctx, dumpFile, dumpSpeed, dumpStartTime, jsonMode, dumpDecode, dumpChanges,
-			dumpFilterPGNs, dumpExcludePGNs, dumpManufacturers, dumpInstances, dumpFilterNames, dumpExcludeNames,
-			displayFilter, devices)
+		for _, path := range files {
+			if ctx.Err() != nil {
+				return nil
+			}
+			if err := runReplay(ctx, path, dumpSpeed, dumpStartTime, jsonMode, dumpDecode, dumpChanges,
+				dumpFilterPGNs, dumpExcludePGNs, dumpManufacturers, dumpInstances, dumpFilterNames, dumpExcludeNames,
+				displayFilter, devices); err != nil {
+				return fmt.Errorf("%s: %w", path, err)
+			}
+		}
+		return nil
 	}
 
 	// Validate mutually exclusive flags.
@@ -325,10 +342,18 @@ func runReplay(ctx context.Context, path string, speed float64, startTimeStr str
 		if speed > 0 && !prevTs.IsZero() {
 			delta := entry.Timestamp.Sub(prevTs)
 			if delta > 0 {
-				time.Sleep(time.Duration(float64(delta) / speed))
+				timer := time.NewTimer(time.Duration(float64(delta) / speed))
+				select {
+				case <-timer.C:
+				case <-ctx.Done():
+					timer.Stop()
+				}
 			}
 		}
 		prevTs = entry.Timestamp
+		if ctx.Err() != nil {
+			break
+		}
 
 		seq := frameSeq
 		if seq == 0 {

--- a/cmd/lplex/cmd_dump.go
+++ b/cmd/lplex/cmd_dump.go
@@ -392,7 +392,7 @@ func runReplay(ctx context.Context, path string, speed float64, startTimeStr str
 		}
 
 		if jsonMode {
-			writeJSONFrame(out, &fr, decode, rawDecoded, ct, diffBytes, fullBytes)
+			writeJSONFrame(out, &fr, devices, decode, rawDecoded, ct, diffBytes, fullBytes)
 		} else {
 			formatFrame(out, &fr, devices, decode, rawDecoded, ct, diffBytes, fullBytes)
 		}
@@ -731,7 +731,7 @@ func streamEvents(sub *lplexc.Subscription, jsonMode, decode, changes bool, f *l
 			}
 
 			if jsonMode {
-				writeJSONFrame(out, ev.Frame, decode, rawDecoded, ct, diffBytes, fullBytes)
+				writeJSONFrame(out, ev.Frame, devices, decode, rawDecoded, ct, diffBytes, fullBytes)
 			} else {
 				formatFrame(out, ev.Frame, devices, decode, rawDecoded, ct, diffBytes, fullBytes)
 			}

--- a/cmd/lplex/decode.go
+++ b/cmd/lplex/decode.go
@@ -206,12 +206,7 @@ func (a *annotatedDecoded) MarshalJSON() ([]byte, error) {
 }
 
 // writeJSONFrame writes a frame as a JSON line, optionally with decoded fields.
-func writeJSONFrame(w *bufio.Writer, f *lplexc.Frame, decode bool, preDecoded any, ct changetracker.ChangeEventType, diffBytes, fullBytes int) {
-	if !decode && ct == 0 {
-		fmt.Fprintf(w, "{\"seq\":%d,\"ts\":\"%s\",\"prio\":%d,\"pgn\":%d,\"src\":%d,\"dst\":%d,\"data\":\"%s\"}\n",
-			f.Seq, f.Ts, f.Prio, f.PGN, f.Src, f.Dst, f.Data)
-		return
-	}
+func writeJSONFrame(w *bufio.Writer, f *lplexc.Frame, dm *deviceMap, decode bool, preDecoded any, ct changetracker.ChangeEventType, diffBytes, fullBytes int) {
 	type jsonFrame struct {
 		Change      string `json:"change,omitempty"`
 		DiffBytes   int    `json:"diff_bytes,omitempty"`
@@ -222,6 +217,7 @@ func writeJSONFrame(w *bufio.Writer, f *lplexc.Frame, decode bool, preDecoded an
 		PGN         uint32 `json:"pgn"`
 		Src         uint8  `json:"src"`
 		Dst         uint8  `json:"dst"`
+		Name        string `json:"name,omitempty"`
 		Data        string `json:"data"`
 		Decoded     any    `json:"decoded,omitempty"`
 		DecodeError string `json:"decode_error,omitempty"`
@@ -229,6 +225,11 @@ func writeJSONFrame(w *bufio.Writer, f *lplexc.Frame, decode bool, preDecoded an
 	jf := jsonFrame{
 		Seq: f.Seq, Ts: f.Ts, Prio: f.Prio,
 		PGN: f.PGN, Src: f.Src, Dst: f.Dst, Data: f.Data,
+	}
+	if dm != nil {
+		if d, ok := dm.get(f.Src); ok {
+			jf.Name = d.Name
+		}
 	}
 	if ct != 0 {
 		jf.Change = ct.String()

--- a/docs/compression.md
+++ b/docs/compression.md
@@ -143,6 +143,6 @@
  ls -la /datalog/lplex/journal/
 
  # replay compressed file
- lplex dump --file /datalog/lplex/journal/<new-file>.lpj
+ lplex dump /datalog/lplex/journal/<new-file>.lpj
 
  Verify: device table populates, frames decode correctly, seeking works.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -154,7 +154,7 @@ curl -s http://localhost:8089/devices | jq .
 ### Recover partial data from corrupt files
 ```bash
 # lplex dump will read frames up to the corrupt block
-lplex dump --file /var/log/lplex/corrupt/nmea2k-CORRUPT.lpj --json > recovered.jsonl
+lplex dump /var/log/lplex/corrupt/nmea2k-CORRUPT.lpj --json > recovered.jsonl
 ```
 
 ---

--- a/website/docs/user-guide/journaling.md
+++ b/website/docs/user-guide/journaling.md
@@ -91,23 +91,26 @@ Set a value to `0` to disable that trigger. At least one should be non-zero.
 
 ## Replaying journals
 
-Use `lplex` to replay journal files:
+Pass one or more journal files as positional args. They are replayed sequentially with a shared device table:
 
 ```bash
-# Normal speed
-lplex dump --file recording.lpj
+# As fast as possible (the default)
+lplex dump recording.lpj
+
+# Multiple files in order — use a glob to grab all rotated journals
+lplex dump /var/lib/lplex/journal/*.lpj
+
+# Real-time speed
+lplex dump recording.lpj --speed 1.0
 
 # 10x speed
-lplex dump --file recording.lpj --speed 10
-
-# As fast as possible
-lplex dump --file recording.lpj --speed 0
+lplex dump recording.lpj --speed 10
 
 # With decoding
-lplex dump --file recording.lpj --decode
+lplex dump recording.lpj --decode
 
-# Seek to a time
-lplex dump --file recording.lpj --start 2026-03-06T10:30:00Z
+# Seek to a time before replaying
+lplex dump recording.lpj --start 2026-03-06T10:30:00Z
 ```
 
 ## Inspecting journals

--- a/website/docs/user-guide/lplex.md
+++ b/website/docs/user-guide/lplex.md
@@ -41,8 +41,8 @@ lplex dump --server http://inuc1.local:8089 --decode
 | `--decode` | `false` | Decode known PGNs into field values |
 | `--where` | (empty) | Display filter expression on decoded fields (auto-enables `--decode`) |
 | `--changes` | `false` | Only show frames with changed data (suppress duplicates within tolerance) |
-| `--file` | (empty) | Replay a `.lpj` journal file instead of connecting |
-| `--speed` | `1.0` | Playback speed for journal replay (0 = max speed) |
+| `--file` | (empty) | Replay a `.lpj` journal file (deprecated; pass files as positional args) |
+| `--speed` | `0` | Playback speed for journal replay (0 = max speed, 1.0 = real-time) |
 | `--start` | (empty) | Seek to this time (RFC 3339) before playing |
 | `--pgn` | (all) | Filter by PGN number (repeatable) |
 | `--exclude-pgn` | (none) | Exclude specific PGN from output (repeatable) |
@@ -250,23 +250,29 @@ lplex dash --refresh 2s
 
 ## Journal replay
 
-Replay a recorded journal file instead of connecting to a live server:
+Pass one or more `.lpj` journal files as positional arguments to replay them sequentially. The shell glob expands naturally:
 
 ```bash
-# Normal speed playback
-lplex dump --file recording.lpj
+# Replay a single file (dumps as fast as possible by default)
+lplex dump recording.lpj
 
-# Fast-forward at 10x
-lplex dump --file recording.lpj --speed 10
+# Replay multiple files in order — device table carries across files
+lplex dump capture-001.lpj capture-002.lpj capture-003.lpj
 
-# As fast as possible (0 is a special value; default is 1.0 = real-time)
-lplex dump --file recording.lpj --speed 0
+# Glob a directory of rotated journals
+lplex dump /var/lib/lplex/journal/*.lpj
 
-# Seek to a specific time
-lplex dump --file recording.lpj --start 2026-03-06T10:00:00Z
+# Real-time playback (1.0 = wall-clock speed)
+lplex dump recording.lpj --speed 1.0
+
+# Fast-forward at 10x real time
+lplex dump recording.lpj --speed 10
+
+# Seek to a specific time before replaying
+lplex dump recording.lpj --start 2026-03-06T10:00:00Z
 
 # Decode during replay
-lplex dump --file recording.lpj --decode
+lplex dump recording.lpj --decode
 
 # Inspect journal structure (block layout, device table, compression)
 lplex inspect recording.lpj
@@ -279,12 +285,16 @@ lplex verify /var/lib/lplex/journal/
 ```
 
 :::note
-`--file`, `--server`, and `--boat` are mutually exclusive. Journal replay does not require a running lplex-server instance.
+Positional file arguments are mutually exclusive with `--server` and `--boat`. Journal replay does not require a running lplex-server instance. The legacy `--file` flag still works for a single file but cannot be combined with positional args.
+:::
+
+:::tip
+`--speed` defaults to `0` (dump as fast as possible) for `lplex dump`. If you want timed playback that other clients can subscribe to, use [`lplex simulate`](#simulation) — it replays through a full HTTP server at real-time speed by default.
 :::
 
 ## Simulation
 
-`lplex simulate` replays journal files through a full HTTP server, simulating a live boat for development and testing. Unlike `lplex dump --file` which outputs frames to stdout, `simulate` starts a real lplex HTTP server that clients can connect to.
+`lplex simulate` replays journal files through a full HTTP server, simulating a live boat for development and testing. Unlike `lplex dump <file>` which outputs frames to stdout, `simulate` starts a real lplex HTTP server that clients can connect to.
 
 ```bash
 # Real-time replay of a single file
@@ -365,7 +375,7 @@ lplex dump --where 'dst.manufacturer == "Garmin"'
 lplex dump --where 'src.model_id == "GPS 19x NMEA 2000"'
 
 # Combine with journal replay
-lplex dump --file recording.lpj --where "pgn == 130306 && wind_speed > 15"
+lplex dump recording.lpj --where "pgn == 130306 && wind_speed > 15"
 ```
 
 ### Expression syntax
@@ -397,7 +407,7 @@ Use `--changes` to suppress duplicate frames and only show meaningful state chan
 lplex dump --server http://inuc1.local:8089 --changes --decode
 
 # Journal replay with change tracking
-lplex dump --file recording.lpj --changes --decode
+lplex dump recording.lpj --changes --decode
 
 # JSON output includes "change" field
 lplex dump --changes --decode --json

--- a/website/docs/user-guide/simulation.md
+++ b/website/docs/user-guide/simulation.md
@@ -7,7 +7,7 @@ title: Simulation & Testing
 
 `lplex simulate` replays recorded journal files through a full HTTP server, simulating a live boat without a CAN bus. This is invaluable for development, integration testing, and demos.
 
-Unlike `lplex dump --file` (which outputs frames to stdout), `simulate` starts a real lplex HTTP server that clients can connect to exactly as they would a live boat.
+Unlike `lplex dump <file>` (which outputs frames to stdout), `simulate` starts a real lplex HTTP server that clients can connect to exactly as they would a live boat.
 
 ## Basic usage
 


### PR DESCRIPTION
## Summary
- `lplex dump` now accepts one or more `.lpj` files as positional args, replayed sequentially with a shared device table (`lplex dump *.lpj`). Legacy `--file` flag retained but errors when combined with positional args.
- Default `--speed` changed from `1.0` (real-time) to `0` (as-fast-as-possible). `dump` is "show me what's in the file"; use `lplex simulate` for timed playback through an HTTP server.
- The replay throttle `time.Sleep` is now cancellable via the signal context, so Ctrl-C exits immediately on sparse-traffic journals (the original report).

Docs updated across README, runbook, compression notes, and the website user guide.

## Test plan
- [ ] `lplex dump file.lpj` exits at EOF without sleeping
- [ ] `lplex dump a.lpj b.lpj` replays both files in order
- [ ] `lplex dump *.lpj --speed 1.0` plays back at real time, Ctrl-C cancels mid-gap
- [ ] `lplex dump --file foo.lpj bar.lpj` returns an error
- [ ] `lplex dump --server http://… foo.lpj` returns an error
- [ ] `cd website && npm run build` succeeds