### PR TITLE
ci: add Dependabot hygiene (pnpm-aware config + cooldown + auto-merge)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# Dependabot keeps dependencies current. For GitHub Actions it bumps the pinned
+# commit SHA *and* the `# vX.Y.Z` comment together, so SHA-pinning (see
+# .github/workflows/*) stays secure without going stale. Updates are grouped per
+# ecosystem into a single weekly PR to keep noise low, and held for a 48h cooldown
+# after a release so freshly-published (and potentially compromised) versions are
+# not adopted immediately. The website's JS deps are pnpm: Dependabot has no
+# `pnpm` ecosystem, so `package-ecosystem: npm` is its label for the whole JS
+# ecosystem and it updates website/pnpm-lock.yaml *as pnpm*. pnpm enforces its
+# own 48h supply-chain cooldown at install time via website/.npmrc
+# (minimum-release-age=2880), so the cooldown holds on both sides.
+# Non-major bumps (and github-actions majors — low-risk, CI-gated action version
+# bumps) are auto-merged once their CI passes; go-module and pnpm majors wait for
+# a human. See .github/workflows/dependabot-auto-merge.yml.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 2
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: ci
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 2
+    groups:
+      golang:
+        patterns: ["*"]
+    commit-message:
+      prefix: go
+
+  # pnpm. `npm` is Dependabot's identifier for the JS ecosystem (npm/yarn/pnpm);
+  # it detects pnpm from website/pnpm-lock.yaml. There is no `pnpm` ecosystem.
+  - package-ecosystem: npm
+    directory: /website
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 2
+    groups:
+      website:
+        patterns: ["*"]
+    commit-message:
+      prefix: docs

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,70 @@
+name: Dependabot auto-merge
+
+# Auto-merge Dependabot PRs once the CI checks that ran for that PR pass.
+# The repo's CI (.github/workflows/ci.yml) runs on every PR, so this job waits
+# for all of those checks to go green before merging.
+# Repo-level auto-merge is disabled, so rather than `gh pr merge --auto` we poll
+# the head commit's check-runs and merge ourselves once they pass.
+#
+# Major version bumps are auto-merged for the github-actions ecosystem only
+# (CI-gated action version bumps are low-risk and still subject to the 48h
+# cooldown). Go-module and npm/pnpm majors are left for a human, since a major
+# library bump can change behaviour even when the tests pass.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Wait for CI, then merge (non-major, or any github-actions bump)
+        # Auto-merge unless it is a major bump outside the github-actions
+        # ecosystem. package-ecosystem comes from the trusted fetch-metadata
+        # action (not a spoofable branch name); confirmed value 'github_actions'.
+        if: steps.meta.outputs.update-type != 'version-update:semver-major' || steps.meta.outputs.package-ecosystem == 'github_actions'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+        run: |
+          set -euo pipefail
+          echo "PR #$PR ($SHA) — update-type=$UPDATE_TYPE"
+          for i in $(seq 1 80); do   # up to ~20 min at 15s intervals
+            # Check runs for this exact commit, excluding this job's own run.
+            runs=$(gh api "repos/$REPO/commits/$SHA/check-runs" --paginate \
+              --jq '.check_runs[] | select(.name != "auto-merge") | [.status, (.conclusion // "")] | @tsv' || true)
+            total=$(printf '%s' "$runs" | grep -c . || true)
+            pending=$(printf '%s\n' "$runs" | awk -F'\t' 'NF && $1!="completed"' | grep -c . || true)
+            failed=$(printf '%s\n' "$runs" | awk -F'\t' 'NF && $1=="completed" && $2!="success" && $2!="neutral" && $2!="skipped"' | grep -c . || true)
+            echo "[$i] checks total=$total pending=$pending failed=$failed"
+
+            if [ "$failed" -gt 0 ]; then
+              echo "A required check failed — leaving the PR for review."
+              exit 0
+            fi
+            if [ "$total" -gt 0 ] && [ "$pending" -eq 0 ]; then
+              echo "All checks green — merging."
+              gh pr merge "$PR" --repo "$REPO" --squash --delete-branch
+              exit 0
+            fi
+            # No checks registered yet: allow a grace period for them to appear
+            # before concluding this PR genuinely has no CI to wait on.
+            if [ "$total" -eq 0 ] && [ "$i" -ge 6 ]; then
+              echo "No CI checks apply to this PR — merging."
+              gh pr merge "$PR" --repo "$REPO" --squash --delete-branch
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "Timed out waiting for checks; leaving the PR open."

--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,0 +1,3 @@
+# Supply-chain safety: a newly published package version must be at least this
+# many minutes old before pnpm will install it. 2880 minutes = 48 hours.
+minimum-release-age=2880


### PR DESCRIPTION
## What

Adds the Dependabot setup this repo was missing — ported from the laredo repo — so dependency updates flow cleanly and don't orphan the way #161 did (a pre-pnpm npm PR against the now-deleted `website/package-lock.json`).

- **`.github/dependabot.yml`** — weekly grouped updates for **github-actions**, **gomod**, and the **website JS** ecosystem, each held **48h by a cooldown**. The website is pnpm; Dependabot has no `pnpm` ecosystem, so `package-ecosystem: npm` is its label for the JS ecosystem and it updates `website/pnpm-lock.yaml` *as pnpm*.
- **`website/.npmrc`** — `minimum-release-age=2880`: pnpm refuses to install any version younger than 48h, so the cooldown also holds at install time (defense in depth; harmless under `--frozen-lockfile` in CI).
- **`.github/workflows/dependabot-auto-merge.yml`** — merges a Dependabot PR once **all its CI checks pass**. Non-major bumps **and github-actions majors** auto-merge (CI-gated, cooldown'd); **go-module and pnpm majors wait for a human**. Gated on the trusted `fetch-metadata` `package-ecosystem` output (not a spoofable branch name).

## Why

Without config, Dependabot ran npm defaults; the website then migrated to pnpm and the open npm PR (#161) became permanently conflicting. This makes future updates pnpm-aware, low-noise, and mostly hands-off, while keeping human review for the bumps that can actually change behaviour.

Companion to #168 (which lands the security fixes #161 was carrying, under pnpm). No application code changes.