### PR TITLE
Support ?decode=true on buffered client SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,14 +404,14 @@ CANWriter goroutine            ReplicationClient (optional)
 
 ### Ephemeral streaming
 
-`GET /events` with optional query params: `pgn`, `exclude_pgn`, `manufacturer`, `instance`, `name` (hex).
+`GET /events` with optional query params: `pgn`, `exclude_pgn`, `manufacturer`, `instance`, `name` (hex). Add `decode=true` to attach a `decoded` object to each frame.
 
 No session, no replay, no ACK. Zero server-side state after disconnect.
 
 ### Buffered sessions
 
 1. `PUT /clients/{id}` with `{"buffer_timeout": "PT5M"}` to create/reconnect
-2. `GET /clients/{id}/events` for SSE (replays from cursor, then live)
+2. `GET /clients/{id}/events` for SSE (replays from cursor, then live); add `decode=true` for decoded frames, same as `/events`
 3. `PUT /clients/{id}/ack` with `{"seq": N}` to advance cursor
 
 Disconnected sessions keep their cursor for the buffer duration.

--- a/server.go
+++ b/server.go
@@ -224,6 +224,9 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 }
 
 // GET /clients/{clientId}/events
+// Replays buffered frames from the session cursor, then streams live.
+// Pass ?decode=true to add a "decoded" field to each frame, matching the
+// ephemeral /events endpoint.
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	clientID := r.PathValue("clientId")
 
@@ -253,6 +256,8 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	s.broker.TouchSession(clientID)
 
+	decode := r.URL.Query().Get("decode") == "true"
+
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -269,6 +274,9 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			s.logger.Error("failed to serialize frame", "error", err)
 			continue
+		}
+		if decode {
+			jsonBytes = injectDecoded(jsonBytes)
 		}
 		w.Write(sseDataPrefix) //nolint:errcheck
 		w.Write(jsonBytes)     //nolint:errcheck

--- a/server_test.go
+++ b/server_test.go
@@ -477,6 +477,99 @@ func TestSSEReplay(t *testing.T) {
 	}
 }
 
+func TestSSEDecode(t *testing.T) {
+	srv, b := newTestServer()
+	defer close(b.rxFrames)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Create session, then connect with ?decode=true (fresh session = live-only,
+	// so connect before injecting).
+	createReq := httptest.NewRequest("PUT", "/clients/decode-test", strings.NewReader(`{"buffer_timeout":"PT1M"}`))
+	srv.ServeHTTP(httptest.NewRecorder(), createReq)
+
+	resp, err := http.Get(ts.URL + "/clients/decode-test/events?decode=true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Inject a valid Position Rapid Update (PGN 129025) — same payload as
+	// TestDecodedValues, which decodes to latitude/longitude.
+	posData := make([]byte, 8)
+	latRaw, lonRaw := int32(476062000), int32(-1223321000)
+	binary.LittleEndian.PutUint32(posData[0:4], uint32(latRaw))
+	binary.LittleEndian.PutUint32(posData[4:8], uint32(lonRaw))
+	injectFrame(b, 129025, 1, posData)
+
+	scanner := bufio.NewScanner(resp.Body)
+	done := make(chan string, 1)
+	go func() {
+		for scanner.Scan() {
+			if line := scanner.Text(); strings.HasPrefix(line, "data: ") {
+				done <- line[6:]
+				return
+			}
+		}
+	}()
+
+	select {
+	case data := <-done:
+		if !strings.Contains(data, `"decoded"`) {
+			t.Errorf("buffered ?decode=true should add a decoded field, got: %s", data)
+		}
+		if !strings.Contains(data, "latitude") || !strings.Contains(data, "longitude") {
+			t.Errorf("decoded frame should contain latitude/longitude, got: %s", data)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for decoded buffered frame")
+	}
+}
+
+func TestSSENoDecodeByDefault(t *testing.T) {
+	srv, b := newTestServer()
+	defer close(b.rxFrames)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	createReq := httptest.NewRequest("PUT", "/clients/raw-test", strings.NewReader(`{"buffer_timeout":"PT1M"}`))
+	srv.ServeHTTP(httptest.NewRecorder(), createReq)
+
+	resp, err := http.Get(ts.URL + "/clients/raw-test/events") // no ?decode
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	posData := make([]byte, 8)
+	latRaw, lonRaw := int32(476062000), int32(-1223321000)
+	binary.LittleEndian.PutUint32(posData[0:4], uint32(latRaw))
+	binary.LittleEndian.PutUint32(posData[4:8], uint32(lonRaw))
+	injectFrame(b, 129025, 1, posData)
+
+	scanner := bufio.NewScanner(resp.Body)
+	done := make(chan string, 1)
+	go func() {
+		for scanner.Scan() {
+			if line := scanner.Text(); strings.HasPrefix(line, "data: ") {
+				done <- line[6:]
+				return
+			}
+		}
+	}()
+
+	select {
+	case data := <-done:
+		if strings.Contains(data, `"decoded"`) {
+			t.Errorf("buffered stream without ?decode should stay raw, got: %s", data)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for raw buffered frame")
+	}
+}
+
 func TestCreateSessionWithFilter(t *testing.T) {
 	srv, b := newTestServer()
 	defer close(b.rxFrames)


### PR DESCRIPTION
## Problem

The buffered client stream (`GET /clients/{id}/events`) only ever emitted **raw** frames — `injectDecoded` was wired into the *ephemeral* `/events` handler but not the buffered one. So a reliable consumer (cursor + ack, no-loss resume) couldn't also get decoded fields: it had to pick resumability **or** decoding, not both.

## Change

Honor `?decode=true` on `handleSSE`, running each frame through `injectDecoded` exactly as `HandleEphemeralSSE` already does. Three lines of behavior; the two SSE paths are now consistent.

```go
decode := r.URL.Query().Get("decode") == "true"
...
if decode {
    jsonBytes = injectDecoded(jsonBytes)
}
```

## Tests

- `TestSSEDecode` — buffered stream with `?decode=true` attaches a `decoded` object (asserts `latitude`/`longitude` from a real 129025 payload).
- `TestSSENoDecodeByDefault` — buffered stream without the flag stays raw (no `decoded` field).

Full suite green (`go test ./...`).

## Motivation

Unblocks [binnacle](https://github.com/sixfathoms/binnacle)'s NMEA 2000 ingest, which wants **at-least-once** delivery (buffered cursor/ack, mirroring its own Journal model) **and** decoded PGNs. Verified end-to-end against a live boat feed (Airmar DST810 + Garmin + Victron bus).